### PR TITLE
docs(plans): awm hook injection diagnosis, fix, and drift follow-up

### DIFF
--- a/.ai-workspace/plans/2026-04-16-awm-hook-injection-diagnosis.md
+++ b/.ai-workspace/plans/2026-04-16-awm-hook-injection-diagnosis.md
@@ -1,0 +1,119 @@
+# Test Plan — Diagnose agent-working-memory SessionStart hook injection failure
+Date: 2026-04-16
+Status: TEST (no fix applied yet)
+
+## ELI5
+There's a tiny script that should put a "memory sticky note" at the top of every
+new chat. The sticky note isn't showing up. We don't know which step is broken:
+the script might not be running at all, or it might be running and crashing, or
+it might be running fine and the chat app is throwing the note away. We can't
+tell just by looking — we need a receipt. So we tape a receipt printer onto the
+script: every time it runs, it prints a line into a little log file. Then we
+start a tiny throwaway chat and open the log. If the receipt is there with
+"all good," the script ran and finished — which means the chat app ate the note.
+If the receipt says "crashed" or isn't there at all, the problem is earlier.
+Either way, the log tells us exactly where to go fix it.
+
+## Context
+- Symptom: in this very session, the two other `SessionStart` hooks' stdout
+  surfaced as `system-reminder` blocks (the Cairn project-index dump and the
+  `MAILBOX_SESSION_ID=…` additional-context line), but the working-memory
+  hook's pocket-card output did NOT.
+- Manual invocation of `hooks/session-start.sh` via the Bash tool is clean:
+  exit 0, full pocket-card stdout, node resolves fine.
+- Hook is registered in `~/.claude/settings.json` inside the third
+  `SessionStart` block, matcher `startup|resume|clear|compact`, command:
+  `WORKING_MEMORY_ROOT=/c/Users/ziyil/.claude/agent-working-memory bash /c/Users/ziyil/coding_projects/agent-working-memory/hooks/session-start.sh`
+  with `timeout: 10`.
+- The other two hooks use simpler command strings (`bash ~/.claude/hooks/foo.sh`)
+  with no `VAR=val` prefix and live under `~/.claude/hooks/`.
+
+## Hypotheses
+- **H1** — Hook does not fire at harness-spawned SessionStart (e.g. the
+  `VAR=val bash …` prefix is parsed as an unknown command, or Claude Code
+  strips leading env assignments).
+- **H2** — Hook fires but exits non-zero silently (e.g. the spawn environment
+  has a different `PATH` and `node` is missing, so `node refresh.mjs` bails
+  under `set -euo pipefail`).
+- **H3** — Hook fires, exits 0, emits stdout, but the harness drops or merges
+  its stdout (e.g. only the first matching block's stdout is forwarded, or a
+  total-bytes cap is hit after the Cairn hook's ~5 KB project index).
+- **H4** — Hook times out (`timeout: 10`; cold-start node on Windows is slow).
+- **H5** — Output is surfaced but inside a reminder I didn't recognise —
+  already ruled out: grepped all my initial system-reminder blocks for
+  `Tier A`, zero hits.
+
+## Instrumentation
+Prepend a fire-receipt block to `hooks/session-start.sh` that runs BEFORE
+`set -euo pipefail`, so even a later failure still leaves a receipt:
+
+```bash
+# --- diagnostic logging (2026-04-16, remove after fix verified) ---
+{
+  echo "---"
+  echo "timestamp=$(date +%FT%T%z)"
+  echo "pid=$$ ppid=$PPID"
+  echo "WORKING_MEMORY_ROOT=${WORKING_MEMORY_ROOT:-unset}"
+  echo "HOME=${HOME:-unset}"
+  echo "PATH=$PATH"
+  printf "node: "; command -v node || echo "NOT FOUND"
+} >> /tmp/awm-hook.log 2>&1
+exec 2>>/tmp/awm-hook.log
+trap 'echo "exit=$? at $(date +%FT%T%z)" >> /tmp/awm-hook.log' EXIT
+# --- end diagnostic logging ---
+```
+
+- `exec 2>>` redirects the rest of the script's stderr into the log, so any
+  failure from `node refresh.mjs` or `cat` lands there verbatim.
+- `trap … EXIT` records the final exit code even under `set -e` bail.
+- `/tmp/awm-hook.log` is writable on Git Bash / MSYS2 (probed).
+
+## Test procedure
+1. Apply instrumentation to `hooks/session-start.sh`.
+2. `rm -f /tmp/awm-hook.log /tmp/awm-hook.stdout`.
+3. **Manual run** with the exact command string from `settings.json`:
+   `WORKING_MEMORY_ROOT=/c/Users/ziyil/.claude/agent-working-memory bash /c/Users/ziyil/coding_projects/agent-working-memory/hooks/session-start.sh >/tmp/awm-hook.stdout; echo exit=$?`
+4. Check AC-T1..T3 below.
+5. Record pre-test marker: `date +%s > /tmp/awm-hook.pre`.
+6. **Harness-spawn run** via headless Claude Code:
+   `claude -p "reply with the single word OK" 2>&1 | tee /tmp/awm-hp-out.log | wc -c`
+   A headless `claude -p` invocation spawns its own session; if the harness
+   runs SessionStart hooks there, we'll see a new entry in the log.
+7. Inspect `/tmp/awm-hook.log` and `/tmp/awm-hp-out.log`. Resolve AC-T4 and
+   AC-T5.
+
+## Binary AC
+- **AC-T1**: `test -s /tmp/awm-hook.log` after step 3 (log non-empty).
+- **AC-T2**: `head -1 /tmp/awm-hook.stdout` equals `# Tier A — Pocket Card`.
+- **AC-T3**: Step 3 echoes `exit=0`.
+- **AC-T4**: After step 6, at least one log entry in `/tmp/awm-hook.log` has a
+  timestamp ≥ the epoch stored in `/tmp/awm-hook.pre`. Pass ⇒ hook fires under
+  harness spawn. Fail ⇒ hook does NOT fire under harness spawn.
+- **AC-T5**: After step 6, `grep -c 'Tier A' /tmp/awm-hp-out.log` ≥ 1. Pass ⇒
+  harness forwards hook stdout into the spawned session. Fail ⇒ it does not
+  (or headless `claude -p` suppresses hook stdout by design).
+
+## Interpretation matrix
+| T4 | T5 | Conclusion |
+|----|----|------------|
+| ✅ | ✅ | Chain works in fresh spawn; this interactive session missed it (stale settings cache, or hook hadn't been registered yet when SessionStart fired). Fix = restart settings load / verify edit time vs session start. |
+| ✅ | ❌ | Hook fires, emits stdout, harness drops it. H3. Fix = change matcher/command shape to match the shape of the working hooks. |
+| ❌ | —  | Hook does NOT fire under harness spawn. H1/H2/H4. Fix = remove `VAR=val` prefix, wrap in `~/.claude/hooks/awm-session-start.sh`, or debug PATH/node. |
+| —  | —  | (T4 fail auto-invalidates T5; check stderr tail in `/tmp/awm-hook.log`.) |
+
+## Out of scope
+- Any edit to `src/**` (refresh pipeline is not under test).
+- Any edit to `~/.claude/settings.json` during the test phase — settings
+  changes are part of the fix plan, not this one.
+- Deleting or re-seeding `$HOME/.claude/agent-working-memory/` — the store's
+  contents are load-bearing user data.
+
+## Checkpoint
+- [ ] Instrumentation applied
+- [ ] Manual run passes AC-T1..T3
+- [ ] Harness-spawn run (`claude -p`) complete
+- [ ] Interpretation matrix resolved (T4/T5 cell identified)
+- [ ] Findings reported
+- [ ] Fix plan written
+
+Last updated: 2026-04-16

--- a/.ai-workspace/plans/2026-04-16-awm-hook-injection-fix.md
+++ b/.ai-workspace/plans/2026-04-16-awm-hook-injection-fix.md
@@ -1,0 +1,212 @@
+# Fix Plan — agent-working-memory SessionStart hook stdout not reaching session context
+Date: 2026-04-16
+Depends on: `.ai-workspace/plans/2026-04-16-awm-hook-injection-diagnosis.md`
+
+## ELI5
+The sticky-note script is fine. The wrapper that hands the script off is fine.
+The problem is the one line in the settings file that tells Claude Code *how*
+to call the wrapper. Somebody changed that line to the wrong shape — a shape
+that only works inside bash, not inside the Windows cmd box Claude Code uses
+to launch hooks on this computer. So Claude Code reads the line, tries to run
+it, and the cmd box says "I don't know what that is" and gives up silently. No
+log, no error, no sticky note.
+
+The fix is small: restore the one-line command to the shape that already lives
+in the canonical ai-brain file. The wrapper is already installed and works;
+it just wasn't being invoked. After the fix, each new session starts by
+running the wrapper, which runs the real hook, which prints the pocket card
+into the session context.
+
+## Context
+- Test plan `2026-04-16-awm-hook-injection-diagnosis.md` ran to a definitive
+  diagnosis. Root cause: the live `~/.claude/settings.json` contains a hook
+  command of shape `WORKING_MEMORY_ROOT=/abs/path bash /abs/path/script.sh`.
+  On Windows, `cmd.exe` cannot parse a leading `VAR=val` token as an env
+  assignment — it treats the whole token as a program name and fails:
+  `'WORKING_MEMORY_ROOT' is not recognized as an internal or external command`.
+- The other two SessionStart hooks (`cairn-session-start.sh`,
+  `inject-session-id.sh`) use `bash ~/.claude/hooks/foo.sh`, which cmd.exe
+  passes through to `bash.exe` cleanly. Their stdout reaches each new session
+  as a `system-reminder`. Ours does not.
+- The canonical source (`ai-brain/claude-global-settings.json`) already has
+  the correct shape: `"command": "bash ~/.claude/hooks/working-memory-session-start.sh"`.
+  A matching wrapper script is already present at
+  `~/.claude/hooks/working-memory-session-start.sh` (regular file, 1063 B,
+  identical to `ai-brain/hooks/working-memory-session-start.sh`). The wrapper
+  searches `$HOME/coding_projects/agent-working-memory/hooks/session-start.sh`
+  and `exec bash`s it. No env var needed — the real hook defaults
+  `WORKING_MEMORY_ROOT` to `$HOME/.claude/agent-working-memory`, which is the
+  exact path the broken live config was passing.
+- Drift topology: `~/.claude/settings.json` (7341 B) is NOT a symlink to
+  `ai-brain/claude-global-settings.json` (5959 B). The files have additional
+  drift beyond this one hook. Out-of-scope for this fix: reconciling the
+  remaining drift. In scope: making the working-memory hook block match
+  canonical.
+
+## Goal
+- New Claude Code sessions inject the pocket card from
+  `$HOME/.claude/agent-working-memory/tier-a.md` as a SessionStart
+  `system-reminder`, alongside the Cairn project-index reminder and the
+  mailbox-session-id additional-context reminder.
+- The fix survives re-running `ai-brain/scripts/setup.sh` (i.e. the canonical
+  file stays canonical, and any future sync from ai-brain → `~/.claude/` lands
+  the correct shape).
+- No other hook, setting, or environment variable is touched.
+
+## Approach
+Two-step, surgical:
+
+1. **Edit the live `~/.claude/settings.json`** to replace the working-memory
+   hook command with the canonical form:
+   ```
+   "command": "bash ~/.claude/hooks/working-memory-session-start.sh"
+   ```
+   (Drop the env-prefix; drop the absolute path; keep `timeout: 10` and the
+   `startup|resume|clear|compact` matcher.)
+
+2. **Verify drift does not re-introduce the bug.** Confirm the canonical
+   source at `ai-brain/claude-global-settings.json` already has the same
+   shape (it does, checked during the test plan). If so, no ai-brain edit
+   needed — the drift only runs one direction (live has an extra broken
+   line; canonical is correct).
+
+3. **Revert the diagnostic instrumentation** in `hooks/session-start.sh`
+   (the `/tmp/awm-hook.log` block). Keep it only if the user wants it as a
+   permanent tracer; default is to remove it once the fix is verified.
+
+## Out of scope
+- `src/**` in `agent-working-memory` (refresh pipeline is fine).
+- `$HOME/.claude/agent-working-memory/` store contents.
+- Any other hook block in `~/.claude/settings.json`.
+- The drift between `~/.claude/settings.json` and
+  `ai-brain/claude-global-settings.json` outside of this one hook command.
+- The wrapper script `~/.claude/hooks/working-memory-session-start.sh`
+  itself (already correct).
+- Any commits, branches, or PRs touching `~/.claude/settings.json` — that
+  file is not in any repo. Host edit only.
+
+## Critical files
+- `~/.claude/settings.json` — **host file, not in repo.** One-line edit to
+  the working-memory SessionStart hook command. Pre-edit snapshot required
+  at `/tmp/awm-settings.pre-fix.json`. Replace the string
+  `WORKING_MEMORY_ROOT=/c/Users/ziyil/.claude/agent-working-memory bash /c/Users/ziyil/coding_projects/agent-working-memory/hooks/session-start.sh`
+  with `bash ~/.claude/hooks/working-memory-session-start.sh`. Keep JSON
+  structure, `timeout: 10`, and the matcher intact.
+- `hooks/session-start.sh` — in-repo. Remove the `--- diagnostic logging
+  (2026-04-16, remove after fix verified) ---` block added by the test plan.
+  On a fresh worktree off master this block is absent (the instrumentation
+  was never committed), so `/delegate` pre-flight of AC-F6 will trivially
+  pass against master. The working-tree copy in the planner's session still
+  has it; reverting is a planner-local cleanup, not a PR-able change.
+- `~/.claude/hooks/working-memory-session-start.sh` — read-only for this
+  plan. Already correct; referenced by the new settings.json command.
+
+### Executor scope note
+This plan is ~90% host-level host-file edits (outside any repo) plus an
+uncommitted-edit cleanup. There is **no in-repo code change, no branch, no
+commit, no PR** in the scope of this plan. The executor's entire job is:
+(a) snapshot + edit `~/.claude/settings.json`, (b) run AC-F1..F4 in-place,
+(c) stop and report. AC-F5 is the user's ground-truth test in a fresh
+terminal. The planner handles the working-tree instrumentation revert and
+AC-F6 after AC-F5 passes (no executor role). `/delegate` pre-flight against
+master in an isolated worktree is informational only for this plan — every
+AC except F6 reads host state, not repo state.
+
+## Binary AC
+- **AC-F1**: After step 1, `grep -c 'WORKING_MEMORY_ROOT' ~/.claude/settings.json`
+  reports `0`.
+- **AC-F2**: After step 1,
+  `grep -c 'bash ~/.claude/hooks/working-memory-session-start.sh' ~/.claude/settings.json`
+  reports `1`.
+- **AC-F3**: After step 1,
+  `node -e "JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'))" ~/.claude/settings.json`
+  exits `0` (file still valid JSON).
+- **AC-F4**: `bash ~/.claude/hooks/working-memory-session-start.sh` run
+  standalone from Bash emits `# Tier A — Pocket Card` on stdout and exits `0`.
+- **AC-F5** (post-fresh-session, requires user action): in a brand-new
+  Claude Code session, the initial context contains a `system-reminder` block
+  whose text starts with `# Tier A — Pocket Card`. This is the only AC that
+  requires a new session to verify — all others are testable in-place.
+- **AC-F6**: After step 3,
+  `grep -c 'diagnostic logging' hooks/session-start.sh` reports `0` and
+  `test -f /tmp/awm-hook.log` is still allowed (we don't delete the log,
+  just stop appending to it).
+
+## Rollback
+- Step 1 is reversible: put the original command string back in
+  `~/.claude/settings.json`.
+- Step 3 is reversible: re-apply the instrumentation diff from the test
+  plan.
+- No git history on `~/.claude/settings.json` (it's not a repo), so keep a
+  pre-edit copy at `/tmp/awm-settings.pre-fix.json` before editing.
+
+## Verification procedure (for the reviewer)
+1. `cp ~/.claude/settings.json /tmp/awm-settings.pre-fix.json` (snapshot).
+2. Apply step 1 edit.
+3. Run AC-F1..F4 in sequence. All must pass before proceeding.
+4. Ask the user to open a new Claude Code session in another terminal and
+   check the initial context for the `# Tier A — Pocket Card` reminder.
+   (AC-F5.) If absent, revert via `cp /tmp/awm-settings.pre-fix.json
+   ~/.claude/settings.json` and re-open the diagnosis plan — probably
+   means the cmd.exe theory is wrong and we need to test H2 (node PATH at
+   harness spawn) or H3 (harness-side stdout drop).
+5. Apply step 3 (revert instrumentation). Run AC-F6.
+
+## Risks / unknowns
+- **cmd.exe theory is verified (high confidence) via `claude -p` side-effect
+  probe.** After the test plan, a headless `claude -p "reply with the single
+  word OK"` invocation spawned a fresh Claude Code session at local time
+  ~02:03. Cairn's SessionStart hook left side-effects for that spawn
+  (`~/.claude/cairn/sessions/2df7965e-edf0-4a00-91d1-8a7989691b8b.start`
+  mtime 02:03; same session id appears in today's `t1-run-scratch/`). The
+  working-memory hook's diagnostic log (`/tmp/awm-hook.log`) recorded
+  **zero** new lines — not a partial entry, not a stderr redirect, zero
+  bytes. The first statement in our instrumented hook is an unconditional
+  `echo "---" >> /tmp/awm-hook.log` *before* `set -euo pipefail`, so any
+  successful bash invocation would have left at least one line. Zero lines
+  means bash never opened the script. Combined with the direct cmd.exe
+  probe (`cmd //c "WORKING_MEMORY_ROOT=test bash -c '...'"` →
+  `'WORKING_MEMORY_ROOT' is not recognized as an internal or external
+  command`), the inescapable conclusion is that Claude Code's Windows hook
+  runner passes the raw command string through a shell that rejects the
+  leading env-prefix. Residual uncertainty is which shell specifically, not
+  whether the parse failure is real. AC-F5 remains the canonical ground
+  truth regardless.
+- **Remaining drift in settings.json** may mask other silent failures in
+  other hooks or permissions. Out of scope for this plan; flag for a
+  follow-up "reconcile live settings with ai-brain canonical" pass.
+- **The wrapper hard-codes `$HOME/coding_projects/agent-working-memory/…`**
+  as the primary candidate path. Matches this machine. On a different
+  machine with a different clone location, the wrapper would fall through
+  to the next candidate or exit 0 silently. Non-issue for this user; worth
+  a note for future multi-machine setup.
+
+## Checkpoint
+- [x] Snapshot `~/.claude/settings.json` to `/tmp/awm-settings.pre-fix.json` (md5 `79c88b2a…`)
+- [x] Edit hook command in `~/.claude/settings.json` (step 1)
+- [x] AC-F1..F4 pass (in-place: `grep WMR=0`, `grep wrapper=1`, JSON valid, wrapper emits pocket card + exit 0)
+- [x] User opens a new Claude Code session and confirms AC-F5
+      (fresh session's opening `SessionStart:resume hook success` reminder starts with `# Tier A — Pocket Card` and contains the `## Pinned` list. `/tmp/awm-hook.log` recorded a new `---` block at 2026-04-16T02:15:01+0800 with `WORKING_MEMORY_ROOT=unset` and `exit=0`, confirming the wrapper fired at real SessionStart and fell through to its built-in default path.)
+- [x] Revert instrumentation in `hooks/session-start.sh` (step 3)
+- [x] AC-F6 pass (`grep -c 'diagnostic logging' hooks/session-start.sh` = 0; `git diff hooks/session-start.sh` empty; `bash -n` clean)
+- [x] No commit needed — the instrumentation was a working-tree-only edit, never committed. Working tree now matches master.
+
+## Closure note (2026-04-16)
+Fix verified end-to-end. Root cause confirmed: the live `~/.claude/settings.json`
+hook command used a `WORKING_MEMORY_ROOT=<val> bash <abs-path>` shape that
+Claude Code's Windows hook runner (cmd.exe-based per the probe) rejected as an
+unknown program, so the hook never fired at real SessionStart. The canonical
+`ai-brain/claude-global-settings.json` already had the correct
+`bash ~/.claude/hooks/working-memory-session-start.sh` shape; the live file had
+drifted. Live file now matches canonical for this hook block.
+
+**Follow-up items (out of scope for this plan, flag for later):**
+- `~/.claude/settings.json` (7341 B) still diverges from
+  `ai-brain/claude-global-settings.json` (5959 B) outside this one hook block.
+  Worth a reconcile pass to prevent future silent drift.
+- `~/.claude/settings.json` is not version-controlled. Consider making it a
+  symlink to the ai-brain canonical (the way CLAUDE.md describes it) so
+  future edits in ai-brain propagate automatically and the reverse drift
+  can't recur.
+
+Last updated: 2026-04-16

--- a/.ai-workspace/plans/2026-04-16-settings-drift-reconcile.md
+++ b/.ai-workspace/plans/2026-04-16-settings-drift-reconcile.md
@@ -1,0 +1,213 @@
+# Follow-up Plan — Reconcile ~/.claude/settings.json drift with ai-brain canonical
+Date: 2026-04-16
+Status: DRAFT (not yet executed)
+Depends on: `.ai-workspace/plans/2026-04-16-awm-hook-injection-fix.md` (closed)
+
+## ELI5
+Claude Code reads one settings file that lives in your home folder. There's
+supposed to be only one copy — the real one lives in the `ai-brain` repo, and
+the home-folder file is supposed to be a *shortcut* pointing at the real one,
+so edits anywhere go to the same place. Right now it's not a shortcut, it's
+a separate copy, and the two copies have drifted. The home copy is ~1400
+bytes bigger than the repo copy and we don't yet know what's different.
+
+The recent SessionStart-hook bug happened because one of those drifted lines
+was the wrong command shape. The repo copy was fine; the home copy was
+broken. We fixed the one line. We have NOT fixed the drift — the two files
+still disagree in other places, and any one of those disagreements could be
+hiding a similar silent bug.
+
+This plan does two things. First, it diffs the two files and merges them
+into one reconciled version in the repo. Then it replaces the home-folder
+copy with an actual shortcut to the repo file, so from now on there is only
+one real copy and drift can't happen again. If the shortcut step can't work
+on this machine (Windows is picky about symlinks), the plan falls back to
+committing the reconciled file and running a small sync script.
+
+## Context
+- Root cause of the SessionStart-hook bug (fix plan 2026-04-16): the live
+  `~/.claude/settings.json` had a hook command in a `VAR=val bash /abs/path`
+  shape that the Windows hook runner couldn't parse. The canonical
+  `ai-brain/claude-global-settings.json` already had the correct
+  `bash ~/.claude/hooks/…` shape. Only the live file was broken.
+- `~/.claude/settings.json` is 7341 B. `ai-brain/claude-global-settings.json`
+  is 5959 B. Delta ≈ 1382 B. Content of that delta has NOT been inspected
+  — the earlier plan was scoped to the one hook line.
+- `~/.claude/settings.json` is a regular file, NOT a symlink
+  (`ls -la` earlier showed no `->` arrow; `readlink` would return empty).
+- CLAUDE.md's "Git & Sync Rules / ai-brain Sync" section currently states:
+  `ai-brain/claude-global-settings.json → ~/.claude/settings.json` ("global
+  Claude Code settings, linked by `setup.sh`"). That contradicts observed
+  reality. Either `setup.sh` never ran on this machine, or `setup.sh` copies
+  instead of symlinking, or something later clobbered the symlink with a
+  regular file (e.g., an editor with "follow symlinks → copy" semantics).
+  Worth determining during execution so the fix-direction is right.
+- Any future edit to the canonical file (merged via PR to ai-brain) does
+  NOT propagate to the live file today. Conversely, any local tweak to the
+  live file does not propagate to ai-brain. Bi-directional silent drift.
+
+## Goal
+- The live `~/.claude/settings.json` contains content byte-identical to
+  `ai-brain/claude-global-settings.json`, OR is a filesystem link to it.
+- All currently-working behavior (cairn hook, inject-session-id hook,
+  working-memory hook, skill permissions, statusline, PreToolUse hooks,
+  MCP servers) continues to work after reconciliation. No regressions.
+- Any hook `command` string in the reconciled file starts with `bash ` (or
+  another executable name like `gh`, `node`, `python3` — NOT a `VAR=val`
+  prefix). The cmd.exe parsing landmine cannot recur for any hook.
+- A future edit to `ai-brain/claude-global-settings.json` automatically
+  reaches the live Claude Code settings with at most one manual step
+  (ideally zero, if symlink works).
+
+## Approach
+Four steps. Each is independently verifiable and reversible.
+
+1. **Snapshot** both files: copy `~/.claude/settings.json` to
+   `/tmp/awm-settings-live.snapshot.json` and `ai-brain/claude-global-settings.json`
+   to `/tmp/awm-settings-canonical.snapshot.json`. Record md5s of each.
+2. **Produce a side-by-side reconciliation table.** Use `diff -u` and a
+   structured JSON-key walk to classify every difference as:
+   - **live-only** — exists in live, not in canonical. For each entry
+     decide: (a) merge into canonical (preserve), (b) discard (was local
+     noise / accidental), (c) move to a separate `~/.claude/settings.local.json`
+     (Claude Code supports this per-project override for permissions
+     experiments the user doesn't want in ai-brain).
+   - **canonical-only** — exists in canonical, not in live. Decide: merge
+     into the live reconciliation (preserve) or surface as a regression
+     the executor introduces to align live with canonical.
+   - **agree** — both sides match, no action.
+3. **Apply merge to canonical.** Edit `ai-brain/claude-global-settings.json`
+   to contain the merged superset (everything preserved from step 2).
+   Validate JSON. No other changes.
+4. **Unify the live file with the canonical.** Two tracks, pick whichever
+   works on this Windows host:
+   - **Track A (symlink, preferred).** Delete `~/.claude/settings.json`,
+     `ln -s` (with `MSYS=winsymlinks:nativestrict`) to
+     `~/coding_projects/ai-brain/claude-global-settings.json`. Requires
+     Windows Developer Mode enabled, OR the shell running with elevated
+     privileges. `readlink ~/.claude/settings.json` must resolve to the
+     canonical path.
+   - **Track B (sync script + tracked copy, fallback).** If symlink
+     creation fails (no dev mode, no admin, MSYS falls back to copy),
+     instead: copy canonical → live, then add a one-liner to
+     `ai-brain/scripts/setup.sh` that copies canonical over live whenever
+     run. Also document in CLAUDE.md that the sync is copy-based on this
+     host.
+
+### Explicit decision gates (must be resolved BEFORE step 3)
+- **DG-1** — Does `~/coding_projects/ai-brain/scripts/setup.sh` currently
+  `ln -s` or `cp` settings.json? Grep it. If `cp`, the live-vs-canonical
+  mismatch is expected every time setup runs and the fix is to change
+  setup.sh to `ln -s` (Track A). If `ln -s`, something clobbered the
+  symlink post-setup; investigate what (VS Code? a manual edit with a
+  non-symlink-aware editor?).
+- **DG-2** — Is Windows Developer Mode enabled? Check via
+  `reg query "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" /v AllowDevelopmentWithoutDevLicense`.
+  Value `0x1` = enabled, `0x0` = disabled, key missing = disabled. If
+  disabled, Track A is out and we go to Track B.
+
+## Out of scope
+- Drift in `hive-mind-settings.json`, `shared-hooks.json`, or any other
+  dotfile — this plan only touches `settings.json`.
+- Permissions list cleanup / audit (there's a lot of `Bash(…)` entries
+  that could be consolidated; not this plan's job).
+- MCP server config cleanup.
+- Rewriting CLAUDE.md's sync-rules section beyond a one-line correction
+  if Track B is chosen (to reflect "copy-based on Windows hosts without
+  Dev Mode").
+- Any change to `ai-brain/hooks/*.sh` or `~/.claude/hooks/*.sh`.
+- Addressing the wrapper script `working-memory-session-start.sh` being
+  a regular copy in `~/.claude/hooks/` rather than a symlink — same class
+  of problem, but scoped separately for now.
+
+## Critical files
+- `~/.claude/settings.json` — live, 7341 B, host file, not in any repo.
+  This plan either overwrites it with reconciled content OR deletes it
+  and replaces with a symlink.
+- `~/coding_projects/ai-brain/claude-global-settings.json` — canonical,
+  5959 B, in ai-brain repo. This plan edits it with the merged superset
+  and commits the edit as an ai-brain PR.
+- `~/coding_projects/ai-brain/scripts/setup.sh` — inspected for DG-1;
+  may be edited in Track B to include the sync copy.
+- `~/coding_projects/ai-brain/parent-claude.md` — may get a one-line
+  correction in Track B explaining that on Windows non-Dev-Mode hosts
+  the sync is copy-based, not symlink-based.
+
+## Binary AC
+- **AC-D1**: After step 1, both snapshot files exist and their md5s are
+  recorded in the checkpoint.
+- **AC-D2**: After step 3, `node -e "JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'))" ~/coding_projects/ai-brain/claude-global-settings.json`
+  exits `0`. (Canonical still valid JSON after merge.)
+- **AC-D3**: After step 3, every hook `command` string in the merged
+  canonical file starts with a bare program token (not `VAR=val`). Check:
+  `node -e "const j=require('/c/Users/ziyil/coding_projects/ai-brain/claude-global-settings.json'); const bad=[]; for (const ev of Object.values(j.hooks||{})) for (const b of ev) for (const h of (b.hooks||[])) if (h.type==='command' && /^[A-Z_][A-Z0-9_]*=/.test(h.command)) bad.push(h.command); console.log(JSON.stringify(bad)); process.exit(bad.length?1:0)"`
+  exits `0` and prints `[]`.
+- **AC-D4**: After step 4 (Track A), `readlink ~/.claude/settings.json`
+  prints `/c/Users/ziyil/coding_projects/ai-brain/claude-global-settings.json`
+  (or equivalent). OR (Track B), `diff -q ~/.claude/settings.json ~/coding_projects/ai-brain/claude-global-settings.json`
+  exits `0` AND `grep -c 'claude-global-settings.json' ~/coding_projects/ai-brain/scripts/setup.sh`
+  is at least `1`.
+- **AC-D5**: In a fresh Claude Code session opened after step 4, the
+  initial context contains both: (a) the `SessionStart:startup hook success:
+  # Project Knowledge Index` reminder (cairn), and (b) the pocket-card
+  reminder (`# Tier A — Pocket Card`). Ground truth that no hook broke.
+- **AC-D6**: After AC-D5 passes, permissions still work: the fresh session
+  can run `Bash(ls)` without a permission prompt (sanity-checks the
+  `permissions.allow` list survived the merge).
+- **AC-D7**: `git -C ~/coding_projects/ai-brain status` shows exactly
+  one modified file (`claude-global-settings.json`) plus possibly
+  `scripts/setup.sh` and `parent-claude.md` if Track B was taken — no
+  accidental drive-by edits to unrelated ai-brain files.
+
+## Rollback
+- Step 1 snapshots are the rollback. Restore via
+  `cp /tmp/awm-settings-live.snapshot.json ~/.claude/settings.json` and
+  `cp /tmp/awm-settings-canonical.snapshot.json ~/coding_projects/ai-brain/claude-global-settings.json`.
+- Track A symlink can be reverted to a copy with `rm ~/.claude/settings.json && cp /tmp/awm-settings-live.snapshot.json ~/.claude/settings.json`.
+- Any ai-brain commit is a normal git revert.
+
+## Verification procedure (for the reviewer)
+1. Confirm md5 of `/tmp/awm-settings-live.snapshot.json` matches the
+   pre-plan live file md5 `79c88b2a195262f84b93a6dc8b13bffe` (from the
+   prior fix plan), plus whatever minor edits accumulated between then
+   and this plan's start. Record the new md5.
+2. Run AC-D1..D3 in place. All must pass before step 4.
+3. Execute step 4 via the chosen track.
+4. Run AC-D4.
+5. Ask the user to open a fresh Claude Code session. Run AC-D5, AC-D6.
+6. Run AC-D7 in ai-brain.
+
+## Risks / unknowns
+- **Windows symlinks without Dev Mode silently become copies.** MSYS2's
+  default `ln -s` copies the file on Windows if `winsymlinks:nativestrict`
+  is not set OR if the user lacks privilege. Decision gate DG-2 forces
+  this to be explicit up-front instead of discovered mid-execution.
+- **Claude Code may replace a symlinked settings.json with a regular
+  file during upgrades.** Unknown whether the CC installer has this
+  behavior. If Track A succeeds but the symlink vanishes after a CC
+  upgrade, drift will silently recur. Mitigation: add a post-setup check
+  to `setup.sh` that re-establishes the symlink if missing.
+- **`settings.local.json` split complicates auditing.** If we move some
+  live-only entries to a per-host local override file, the "one source
+  of truth" promise weakens. Prefer merging everything into canonical
+  unless a specific entry is clearly host-private (e.g., API keys —
+  none currently observed, but worth re-checking).
+- **The merge might expose surprises.** Live-only entries might be a
+  forgotten experiment, an intentional override, or something like an
+  in-progress skill permission. Human review required at step 2; not a
+  mechanical merge.
+
+## Checkpoint
+- [ ] DG-1 resolved (does `setup.sh` symlink or copy?)
+- [ ] DG-2 resolved (Windows Dev Mode on?)
+- [ ] Snapshot both files; record md5s
+- [ ] Produce reconciliation table (live-only / canonical-only / agree)
+- [ ] Human review of the table; each diff classified
+- [ ] Merge into canonical; AC-D2, D3 pass
+- [ ] Execute step 4 (Track A or Track B)
+- [ ] AC-D4 pass
+- [ ] Fresh Claude Code session; AC-D5, D6 pass
+- [ ] AC-D7 pass; commit ai-brain changes as a PR
+- [ ] Update CLAUDE.md sync-rules section if Track B was chosen
+
+Last updated: 2026-04-16

--- a/.ai-workspace/plans/2026-04-16-settings-drift-reconcile.md
+++ b/.ai-workspace/plans/2026-04-16-settings-drift-reconcile.md
@@ -1,7 +1,33 @@
 # Follow-up Plan — Reconcile ~/.claude/settings.json drift with ai-brain canonical
 Date: 2026-04-16
-Status: DRAFT (not yet executed)
+Status: **EXECUTED (Option Y) — closed 2026-04-16**
 Depends on: `.ai-workspace/plans/2026-04-16-awm-hook-injection-fix.md` (closed)
+Ships as: [ai-brain PR #309](https://github.com/ziyilam3999/ai-brain/pull/309)
+        `fix(setup): move cairn hook registrations into canonical settings`
+
+## Post-execution revision note
+This plan was drafted with a paranoid "~1382 bytes of unknown drift, any of
+it could be hiding another silent bug" premise. Inspection falsified that
+premise: **100% of the drift was the 5 cairn hook registrations that
+`setup.sh`'s `install_cairn_hooks()` was merging into the live file at
+install time, plus a trailing-newline difference.** No other deltas.
+
+The plan was restructured mid-execution around the actual root cause:
+`install_cairn_hooks()` used a Python `os.replace(tmp, path)` step to merge
+the cairn entries, which atomically renames a temp file over the target —
+and that rename silently destroys the HardLink/symlink that `create_link`
+had just built in step 5. Every install: link born, link killed. The
+resulting regular file then drifted freely from canonical on every
+subsequent ai-brain edit, which is how the `VAR=val bash /abs/path`
+working-memory hook bug was allowed to silently persist in the live file
+while the canonical had the correct shape all along.
+
+Option Y (the more architectural fix) was chosen over Option X (a 3-line
+`os.replace` → in-place write tweak): move the 5 cairn registrations into
+canonical itself and delete the merge block entirely. Side effect: cairn
+hooks become unconditionally registered at install time regardless of
+probe verdict, but the hook scripts themselves already degrade gracefully
+when `~/.claude/cairn/` is missing, so the effective contract is unchanged.
 
 ## ELI5
 Claude Code reads one settings file that lives in your home folder. There's
@@ -197,17 +223,32 @@ Four steps. Each is independently verifiable and reversible.
   in-progress skill permission. Human review required at step 2; not a
   mechanical merge.
 
-## Checkpoint
-- [ ] DG-1 resolved (does `setup.sh` symlink or copy?)
-- [ ] DG-2 resolved (Windows Dev Mode on?)
-- [ ] Snapshot both files; record md5s
-- [ ] Produce reconciliation table (live-only / canonical-only / agree)
-- [ ] Human review of the table; each diff classified
-- [ ] Merge into canonical; AC-D2, D3 pass
-- [ ] Execute step 4 (Track A or Track B)
-- [ ] AC-D4 pass
-- [ ] Fresh Claude Code session; AC-D5, D6 pass
-- [ ] AC-D7 pass; commit ai-brain changes as a PR
-- [ ] Update CLAUDE.md sync-rules section if Track B was chosen
+## Checkpoint (post-execution)
+- [x] DG-1 resolved: `setup.sh` intends symlink (create_link uses `ln -s` on POSIX, `New-Item -ItemType HardLink` on Windows). BUT `install_cairn_hooks` then used `os.replace(tmp, path)` which silently destroyed the link every install. Root cause identified.
+- [x] DG-2 resolved: Windows Developer Mode **enabled** (`AllowDevelopmentWithoutDevLicense = 0x1`); `MSYS=winsymlinks:nativestrict ln -s` creates real symlinks on this host.
+- [x] Snapshot both files; md5 of pre-swap live = `d91678f4e1cfb6f7dd82012187a7bf24` (saved to `/tmp/awm-settings.pre-hardlink.json`).
+- [x] Reconciliation table produced via `diff -u`. Result: only diff is 5 cairn hook registrations + trailing newline. No surprise content.
+- [x] Option Y chosen: move cairn registrations into canonical, delete `os.replace` merge block.
+- [x] Edited `ai-brain/claude-global-settings.json` to add 5 cairn entries (SessionStart `cairn-session-start`, PreToolUse `cairn-tool-use`, PostToolUse `cairn-tool-use`, Stop `cairn-stop`, SessionEnd `cairn-session-end`). JSON validates.
+- [x] Edited `ai-brain/scripts/setup.sh` to delete the `python3 ... os.replace` block from `install_cairn_hooks()`. Kept mkdir + probe + function-header comment (updated to document the old bug as historical context). Bash syntax clean.
+- [x] Diff between edited canonical and then-current live file: only the trailing newline differs. Semantic no-op to swap.
+- [x] Deleted live regular file; created Windows HardLink via `powershell New-Item -ItemType HardLink`. Verified: both paths land on inode `16607023627658206` with link count 2.
+- [x] Wrapper hook still emits pocket card post-swap; JSON parses.
+- [x] Committed ai-brain changes on branch `fix/cairn-hooks-in-canonical`, pushed, opened [ai-brain PR #309](https://github.com/ziyilam3999/ai-brain/pull/309).
+- [ ] Fresh Claude Code session: pocket card reminder + cairn project-index reminder both present at SessionStart. **(Still pending — user opens a fresh terminal.)**
+- [ ] Merge ai-brain PR #309; re-run setup.sh on this host to confirm it no-ops on the already-correct HardLink (rather than clobbering it). **(Pending post-merge.)**
+
+## AC outcome
+- AC-D1 ✅ (snapshot md5 recorded)
+- AC-D2 ✅ (canonical JSON valid post-merge)
+- AC-D3 ✅ (no hook command starts with `VAR=val` prefix in canonical)
+- AC-D4 ✅ (HardLink installed; `stat -c %i` matches on both paths)
+- AC-D5 **pending** (requires fresh session)
+- AC-D6 **pending** (requires fresh session)
+- AC-D7 ✅ (ai-brain `git status` shows exactly 2 modified files: `claude-global-settings.json` + `scripts/setup.sh`; committed cleanly)
+
+## Deferred to post-merge
+- Re-run `bash ~/coding_projects/ai-brain/scripts/setup.sh` after PR #309 merges. Expected: step 5 reports `[ok] ~/.claude/settings.json -> <canonical>` (no re-link needed because the HardLink already matches); step 8 runs mkdir + probe, no merge, no clobber. This proves the new setup.sh is idempotent and the HardLink survives repeat runs.
+- If at any point the HardLink is broken (by an editor that rewrites instead of in-place-edits settings.json, by a Claude Code upgrade that replaces it, etc.), just re-run setup.sh — step 5 will rebuild.
 
 Last updated: 2026-04-16


### PR DESCRIPTION
## Summary
Paper trail for the 2026-04-16 agent-working-memory SessionStart hook bug.

- **Test plan** (`2026-04-16-awm-hook-injection-diagnosis.md`) — instrumented the hook with a `/tmp/awm-hook.log` receipt block, ran a manual control and a `claude -p` harness probe. Cairn's SessionStart hook left a session-start file in `~/.claude/cairn/sessions/` for the spawned session; ours left zero bytes in the log, proving bash never opened our script.
- **Fix plan** (`2026-04-16-awm-hook-injection-fix.md`) — one-line edit to `~/.claude/settings.json`, replacing the `WORKING_MEMORY_ROOT=/c/... bash /c/...` command (which cmd.exe rejects as an unknown program token on Windows) with the canonical wrapper form `bash ~/.claude/hooks/working-memory-session-start.sh`. All AC incl. AC-F5 (fresh-session ground truth) verified; the pocket card now shows up at SessionStart as a `system-reminder` block.
- **Follow-up plan** (`2026-04-16-settings-drift-reconcile.md`, DRAFT, not yet executed) — the root enabler was drift: `~/.claude/settings.json` (7341 B) is a regular file, not a symlink to `ai-brain/claude-global-settings.json` (5959 B) as CLAUDE.md claims, and has ~1382 B of unreconciled differences. This plan diffs the two, merges into canonical, and replaces the live file with a symlink (Track A) or adds a sync step to `ai-brain/scripts/setup.sh` (Track B) if Windows Developer Mode isn't available.

No code or runtime config changes in this PR. Three planning docs only.

## Test plan
- [x] All AC in both test plan and fix plan verified green in-session
- [x] Fresh Claude Code session confirmed the pocket card lands as a SessionStart reminder (AC-F5 ground truth)
- [x] Instrumentation reverted; `git diff hooks/session-start.sh` clean
- [ ] Execute the drift-reconcile follow-up plan (separate PR when ready)