### PR TITLE
fix(refresh): guard resolveRoot against unexpanded shell tokens

### DIFF
--- a/src/refresh.mjs
+++ b/src/refresh.mjs
@@ -8,9 +8,33 @@ import { join } from "node:path";
 import { homedir } from "node:os";
 import { loadCards, compact, DEFAULT_BUDGET } from "./compact.mjs";
 
+// Guard against shell tokens that were never expanded by the parent process
+// (e.g. Claude Code's env block ships literal values, so a config like
+// "$HOME/.claude/agent-working-memory" leaks the $HOME token into this
+// process). Writing to such a path creates a bogus directory named $HOME
+// under the current working directory. Refuse loudly instead of silently
+// misrouting writes. See plan:
+//   forge-harness/.ai-workspace/plans/2026-04-19-memory-cli-home-leak-fix.md
+const UNEXPANDED_TOKEN_RE = /\$\{?[A-Za-z_][A-Za-z0-9_]*\}?/;
+
+function assertExpandedPath(candidate, source) {
+  const match = UNEXPANDED_TOKEN_RE.exec(candidate);
+  if (match) {
+    throw new Error(
+      `resolveRoot: ${source} contains an unexpanded shell token (${match[0]}) in value ` +
+      `"${candidate}". Refusing to return a path with a literal $VAR — writing to it ` +
+      `would create a bogus directory under CWD. Fix: unset the env var so the default ` +
+      `${'$'}HOME-based fallback fires, or pass a fully-expanded absolute path.`,
+    );
+  }
+  return candidate;
+}
+
 export function resolveRoot(argRoot) {
-  if (argRoot) return argRoot;
-  if (process.env.WORKING_MEMORY_ROOT) return process.env.WORKING_MEMORY_ROOT;
+  if (argRoot) return assertExpandedPath(argRoot, "argRoot");
+  if (process.env.WORKING_MEMORY_ROOT) {
+    return assertExpandedPath(process.env.WORKING_MEMORY_ROOT, "WORKING_MEMORY_ROOT env var");
+  }
   return join(homedir(), ".claude", "agent-working-memory");
 }
 

--- a/tests/resolve-root.test.mjs
+++ b/tests/resolve-root.test.mjs
@@ -1,0 +1,87 @@
+// Tests for resolveRoot() guard against unexpanded shell tokens.
+//
+// Context: Claude Code's global settings env block ships literal values to
+// child processes, so a config like "$HOME/.claude/..." leaks the literal
+// $HOME token into WORKING_MEMORY_ROOT. Writing to that path creates a
+// bogus directory named $HOME under the current working directory. The
+// guard refuses such paths loudly.
+//
+// Plan: forge-harness/.ai-workspace/plans/2026-04-19-memory-cli-home-leak-fix.md
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveRoot } from "../src/refresh.mjs";
+
+// AC-02: guard throws when WORKING_MEMORY_ROOT holds a literal, unexpanded
+// $HOME token.
+test("resolveRoot: throws on literal unexpanded $HOME in WORKING_MEMORY_ROOT env var", () => {
+  const prev = process.env.WORKING_MEMORY_ROOT;
+  process.env.WORKING_MEMORY_ROOT = "$HOME/.claude/agent-working-memory";
+  try {
+    assert.throws(
+      () => resolveRoot(),
+      /unexpanded shell token.*HOME/,
+      "expected resolveRoot to throw naming the offending HOME token",
+    );
+  } finally {
+    if (prev === undefined) delete process.env.WORKING_MEMORY_ROOT;
+    else process.env.WORKING_MEMORY_ROOT = prev;
+  }
+});
+
+// Same class of bug with ${HOME} (curly-brace form).
+test("resolveRoot: throws on literal ${HOME} (curly-brace form) in env var", () => {
+  const prev = process.env.WORKING_MEMORY_ROOT;
+  process.env.WORKING_MEMORY_ROOT = "${HOME}/.claude/agent-working-memory";
+  try {
+    assert.throws(
+      () => resolveRoot(),
+      /unexpanded shell token.*HOME/,
+      "expected resolveRoot to throw naming the offending HOME token",
+    );
+  } finally {
+    if (prev === undefined) delete process.env.WORKING_MEMORY_ROOT;
+    else process.env.WORKING_MEMORY_ROOT = prev;
+  }
+});
+
+// Guard also triggers when an unexpanded token is passed via argRoot.
+test("resolveRoot: throws on literal unexpanded $VAR in argRoot", () => {
+  assert.throws(
+    () => resolveRoot("$WORKING_MEMORY_ROOT/tier-b"),
+    /unexpanded shell token/,
+    "expected resolveRoot to throw when argRoot contains a literal $VAR",
+  );
+});
+
+// AC-03: with WORKING_MEMORY_ROOT unset, fallback expands correctly to an
+// absolute path under the user's home directory.
+test("resolveRoot: unset env var falls back to expanded $HOME-based absolute path", () => {
+  const prev = process.env.WORKING_MEMORY_ROOT;
+  delete process.env.WORKING_MEMORY_ROOT;
+  try {
+    const root = resolveRoot();
+    assert.ok(root && typeof root === "string", "expected non-empty string");
+    assert.ok(
+      !/\$\{?[A-Za-z_]/.test(root),
+      `fallback path must not contain unexpanded tokens, got: ${root}`,
+    );
+    // Absolute path — either POSIX (/c/...) or Windows drive (C:\...).
+    assert.ok(
+      /^([A-Za-z]:[\\/]|\/)/.test(root),
+      `expected absolute path, got: ${root}`,
+    );
+    assert.ok(
+      root.includes("agent-working-memory"),
+      `expected path to end under agent-working-memory, got: ${root}`,
+    );
+  } finally {
+    if (prev !== undefined) process.env.WORKING_MEMORY_ROOT = prev;
+  }
+});
+
+// Explicit, fully-expanded argRoot is accepted unchanged.
+test("resolveRoot: fully-expanded argRoot is returned unchanged", () => {
+  const input = "/tmp/fake/agent-working-memory";
+  assert.equal(resolveRoot(input), input);
+});


### PR DESCRIPTION
## Summary

Adds a defensive guard in `resolveRoot()` that throws if the `WORKING_MEMORY_ROOT` env var contains an unexpanded shell token (`$HOME`, `${HOME}`, `$WORKING_MEMORY_ROOT`, etc.). Without this guard, a misconfigured env literal silently writes files to paths like `$HOME/.claude/...` inside whatever the current working directory is — observed in forge-harness 2026-04-18 (task #74).

Paired with ai-brain PR #374 which unsets the env var at source. This PR is the belt-and-suspenders safety rail against future re-introduction.

New tests under `tests/resolve-root.test.mjs` cover:
- Guard throws on literal `$HOME/...` env
- Guard throws on `${HOME}/...` env
- Guard throws on `$WORKING_MEMORY_ROOT/...` self-reference
- Fallback expands correctly when env is unset (no regression)
- Explicit `--root` arg bypasses env (no regression)

## Test plan

- [x] `npm test` delta: no new failures vs main baseline (pre-existing `hygiene: committed repo tree is clean` remains out-of-scope)
- [x] `WORKING_MEMORY_ROOT='$HOME/.claude/agent-working-memory' node -e '...resolveRoot()...'` exits 42 with error message naming `HOME`
- [x] `unset WORKING_MEMORY_ROOT && node -e '...resolveRoot()...'` prints expanded absolute path
- [x] Acceptance wrapper in forge-harness task #74 plan: 8/8 AC PASS

Related: forge-harness task #74, plan at `forge-harness/.ai-workspace/plans/2026-04-19-memory-cli-home-leak-fix.md`. PR 2 of 3.