### PR TITLE
fix(hygiene): scan tracked files only (closes #8)

### DIFF
--- a/src/hygiene.mjs
+++ b/src/hygiene.mjs
@@ -16,7 +16,8 @@
 // is the only place those mentions may live.
 
 import { readdirSync, readFileSync, statSync } from "node:fs";
-import { join, relative, sep } from "node:path";
+import { join, relative, sep, isAbsolute } from "node:path";
+import { execFileSync } from "node:child_process";
 
 const ALLOWLIST = new Set([
   "src/hygiene.mjs",
@@ -72,8 +73,33 @@ export function scanFile(path, relPath) {
   return violations;
 }
 
+// Return tracked files under `root` as absolute paths, or null if `root` is
+// not inside a git repo (e.g., the tmp-dir seeded-probe test). The hygiene
+// scanner's contract is "committed repo tree is clean", so we ask git what
+// belongs to the committed tree rather than walking the filesystem and
+// sweeping up untracked WIP.
+function listTrackedFiles(root) {
+  let out;
+  try {
+    out = execFileSync("git", ["ls-files", "-z"], {
+      cwd: root,
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+  } catch {
+    return null;
+  }
+  const text = out.toString("utf8");
+  if (text.length === 0) return [];
+  return text
+    .split("\0")
+    .filter(Boolean)
+    .map(rel => (isAbsolute(rel) ? rel : join(root, rel)));
+}
+
 export function scanTree(root) {
-  const files = walk(root);
+  const tracked = listTrackedFiles(root);
+  const files = tracked !== null ? tracked : walk(root);
   const all = [];
   for (const f of files) {
     const rel = relative(root, f).split(sep).join("/");


### PR DESCRIPTION
## Summary

Teach `scanTree()` in `src/hygiene.mjs` to ask git for the tracked file set (`git ls-files -z`) rather than walking the whole filesystem. When the root is not a git repo (e.g. the seeded-probe test at `tests/hygiene.test.mjs:26`), fall back to the existing `walk()` — the non-git-repo path is preserved.

This closes the gap between the hygiene test's declared invariant ("hygiene: committed repo tree is clean") and what the scanner actually checked (entire working tree, including untracked WIP). As of `e7e335a` the committed tree is already clean and CI is green; the bug was purely local-dev-ergonomic — contributors with uncommitted plans under `.ai-workspace/` saw `npm test` go red for scratch the repo doesn't ship.

Implementation: one new helper `listTrackedFiles(root)` returning `null` when git errors (fall-back-to-walk sentinel) vs `[]` when the repo is legitimately empty (committed tree is clean by definition). `walk()`, `scanFile()`, `ALLOWLIST`, `PATTERNS`, `SKIP_DIRS`, and the CLI entry are unchanged in semantics.

Closes #8.

## Test plan

- [x] AC-1 — `npm test` stays green with a seeded untracked `~/.claude/…` probe under `.ai-workspace/` (exit 0 with `# pass 15 # fail 0`)
- [x] AC-2 — programmatic `scanTree(process.cwd())` does NOT report an untracked seeded probe (exit 0)
- [x] AC-3 — `scanTree(<tmp-dir>)` still flags a seeded probe in a non-git-repo root (exit 0; walk-fallback regression guard)
- [x] AC-4 — no diff in `package.json` / `package-lock.json`
- [x] AC-5 — no diff in `tests/`
- [x] AC-6 — `git diff --name-only origin/main..HEAD` is exactly `src/hygiene.mjs`

All verified locally against branch HEAD `ff92237`.