### PR TITLE
fix: include err.message in fallback stderr log (#15)

### DIFF
--- a/src/hygiene.mjs
+++ b/src/hygiene.mjs
@@ -100,7 +100,7 @@ function listTrackedFiles(root) {
     const expectedStatus = err && [128, null].includes(err.status);
     const expectedCode = err && ["ENOENT", "EACCES", "EPERM"].includes(err.code);
     if (err && !expectedStatus && !expectedCode) {
-      process.stderr.write(`hygiene: listTrackedFiles fell back to walk (${err.code || err.message})\n`);
+      process.stderr.write(`hygiene: listTrackedFiles fell back to walk (${err.code || 'error'}: ${err.message})\n`);
     }
     return null;
   }


### PR DESCRIPTION
Closes #15

Auto-fix by /housekeep Stage 4.

Rewrote the fallback stderr warning template in `src/hygiene.mjs:99` to include both `err.code` and `err.message`.