### PR TITLE
feat(content-sync): auto-sync pinned cards + memory-liveness panel (v0.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.2.0](https://github.com/ziyilam3999/agent-working-memory/compare/v0.1.4...v0.2.0) (2026-04-25)
+
+### Features
+
+* **content-sync:** auto-sync pinned tier-b cards to the private content-repo backup. New `scripts/content-sync.mjs` (dry-run + full-run modes), filter predicate at `scripts/lib/content-filter.mjs`, four new tests covering filter / hash-edit detection / idempotency / non-pinned exclusion. PM2 entry `working-memory-content-sync` in new `ecosystem.config.cjs` runs daily at 04:30 local. `npm run sync` is the manual escape hatch. Failure path writes a single-line record to `<clone>/.last-sync-error.log` and exits non-zero. PR B of the memory-status pass — closes plan `.ai-workspace/plans/2026-04-25-memory-status-pass.md` ACs B1-B10.
+* **refresh:** consume the Cairn status fragment (PR A producer) and embed the `## Memory liveness` panel in tier-a.md with four-branch graceful behavior — fresh / absent / malformed / stale. Freshness window: 8h, matching H7's cron cadence.
+
 ## [0.1.4](https://github.com/ziyilam3999/agent-working-memory/compare/v0.1.3...v0.1.4) (2026-04-20)
 
 ### Miscellaneous

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -9,3 +9,79 @@ The installer does not touch global settings. To register the SessionStart hook,
 ## Forward reference: P4 /ship integration
 
 In a later phase, the `/ship` skill will call `memory write` after a successful merge so every shipped PR yields a decision card. That wiring is out of scope for v0.1.0 — the mechanism just has to exist and be stable enough to wire into.
+
+## v0.2.0: content-repo auto-sync
+
+Pinned tier-b cards are mirrored to a private GitHub backup repo so a fresh machine can rehydrate by cloning. The mirror is one-way (local to backup); the backup is never the source of truth. Source code at `scripts/content-sync.mjs`, filter predicate at `scripts/lib/content-filter.mjs`.
+
+### What gets synced
+
+Phase 1 of the card-tracking strategy: only **pinned** cards under `tier-b/topics/` are tracked. Non-pinned cards remain local-only. The filter predicate is intentionally narrow — broadening it is a future phase.
+
+The dry-run mode previews the action plan without writing anything:
+
+    node scripts/content-sync.mjs --dry-run
+
+Each line is one of `ADD <path>`, `UPDATE <path>`, `DELETE <path>`, or `SKIP-FILTER <path> reason=<token>`. Output is sorted by path so two consecutive runs are byte-identical.
+
+### Manual escape hatch
+
+After pinning a card you want pushed immediately (rather than waiting for the next cron window):
+
+    npm run sync
+
+Same code path as the cron entry — one knob to learn.
+
+### Cron schedule
+
+PM2 entry in `ecosystem.config.cjs` runs the sync daily at 04:30 local. Activate once with:
+
+    pm2 start ecosystem.config.cjs
+    pm2 save
+
+The cron expression is `30 4 * * *`, staggered after ai-brain's H5 (03:00) and H6 (Mon 04:00) so the daemon's cron storms do not all land on the same minute.
+
+### Configuration
+
+All env vars are optional; defaults match the production layout.
+
+| Var | Default | Purpose |
+|---|---|---|
+| `WORKING_MEMORY_ROOT` | tier-b root under the user's Claude home | Source tier-b root |
+| `CONTENT_REPO_CLONE` | content-repo-clone under the user's Claude home | Local clone of the backup repo |
+| `CONTENT_REPO_REMOTE` | upstream HTTPS URL of the backup repo | Remote URL — overridable for tests |
+| `CONTENT_REPO_BRANCH` | `main` | Target branch on the backup repo |
+| `CONTENT_SYNC_SKIP_PUSH` | unset | Set to `1` to skip the push step (useful when the remote is down) |
+| `CONTENT_SYNC_AUTHOR_NAME` | (uses git global) | Override commit author name |
+| `CONTENT_SYNC_AUTHOR_EMAIL` | (uses git global) | Override commit author email |
+
+### Bootstrap order on a fresh machine
+
+ai-brain's PM2 ecosystem (`cairn-h4`, `cairn-h5`, `cairn-h6`, `cairn-h7`) should start before agent-working-memory's. H7 fires every 6h and writes the Cairn status fragment to the user's Claude home. The SessionStart hook in this repo embeds that fragment in tier-a.md when present, falling back gracefully when absent — so a session that starts before the first H7 fire will not see the memory-liveness panel until ~6h after Cairn comes up. The auto-sync cron itself does not depend on the fragment.
+
+### Failure observability
+
+When the sync hits an unrecoverable error (network, auth, push rejection that exhausted the rebase retry budget), the script:
+
+1. Exits with code 1.
+2. Writes a single-line failure record to `<CONTENT_REPO_CLONE>/.last-sync-error.log` carrying timestamp + error class. The file is overwritten each run (last-error-only — operators tail the file rather than scroll history).
+
+The retry budget for `git pull --rebase` collisions is 3 attempts. After the budget is exhausted the script gives up and surfaces the failure record.
+
+### How to disable
+
+    pm2 stop working-memory-content-sync
+    pm2 delete working-memory-content-sync
+
+The repo on disk and any committed cards are untouched; only the cron entry is removed.
+
+## Memory-liveness panel in tier-a
+
+`src/refresh.mjs` consumes the Cairn status fragment (default path under the user's Claude home, overridable via `CAIRN_STATUS_FRAGMENT`) and embeds the `## Memory liveness` panel at the bottom of tier-a.md. Four-branch graceful behavior:
+
+- **fresh** (anchor present, mtime within 8h) — panel embedded as-is
+- **absent** (file missing) — tier-a is unchanged
+- **malformed** (anchor missing) — tier-a carries a single `_memory-liveness: malformed_` note
+- **stale** (anchor present, mtime > 8h) — panel embedded WITH age annotation in the heading
+
+The 8h freshness window matches the H7 cron cadence's freshness window in ai-brain's `cairn/lib/heartbeat-reader.mjs`.

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,0 +1,55 @@
+// PM2 ecosystem owned by agent-working-memory.
+//
+// One app — `working-memory-content-sync` — runs scripts/content-sync.mjs on
+// a daily cron to keep pinned tier-b cards in lockstep with the GitHub backup
+// repo `agent-working-memory-content`.
+//
+// Coexistence: this file is INTENTIONALLY separate from ai-brain's
+// ecosystem.config.cjs. The `working-memory-` prefix on the app name keeps
+// the two PM2 namespaces from colliding on the host's daemon. See plan
+// `.ai-workspace/plans/2026-04-25-memory-status-pass.md` Goal §6 + B6
+// "Coexistence" clause.
+//
+// Bootstrap order: ai-brain's PM2 entries (Cairn H4-H7 + housekeep) should
+// start before this one so the H7 cron has fired at least once and the
+// status fragment at $HOME/.claude/cairn/status-fragment.md exists before
+// any session consumer reads it. agent-working-memory's sync runner does
+// NOT consume the fragment — only the SessionStart-hook tier-a refresh
+// does — so the order is best-practice rather than a hard dependency.
+//
+// Activation:
+//   pm2 start ecosystem.config.cjs   # one-shot; pm2 keeps the schedule
+//   pm2 save                         # persist across reboots
+//
+// Disable:
+//   pm2 stop working-memory-content-sync
+//   pm2 delete working-memory-content-sync
+
+const path = require("node:path");
+const REPO = __dirname;
+
+module.exports = {
+  apps: [
+    {
+      // Globally unique name across all ecosystem files registered against
+      // the host's PM2 daemon. The "working-memory-" prefix gives namespace
+      // separation from ai-brain's "cairn-h4/h5/h6/h7" + "housekeep" apps.
+      name: "working-memory-content-sync",
+      script: "scripts/content-sync.mjs",
+      interpreter: "node",
+      // Daily at 04:30 local — staggered after ai-brain's H5 (03:00) and
+      // H6 (Mon 04:00) so the cron storms don't pile up on the same minute.
+      cron_restart: "30 4 * * *",
+      autorestart: false,
+      watch: false,
+      cwd: REPO,
+      env: {
+        NODE_ENV: "production",
+        PATH: process.env.PATH,
+      },
+      out_file: path.join(REPO, ".pm2", "content-sync.out.log"),
+      error_file: path.join(REPO, ".pm2", "content-sync.err.log"),
+      kill_timeout: 600000,
+    },
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-working-memory",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "Two-tier decision memory for Claude Code: Tier A pocket card + Tier B decision library.",
   "type": "module",
   "bin": {
@@ -11,7 +11,8 @@
     "hygiene": "node src/hygiene.mjs .",
     "refresh": "node src/refresh.mjs",
     "compact": "node src/compact.mjs",
-    "write-card": "node src/write-card.mjs"
+    "write-card": "node src/write-card.mjs",
+    "sync": "node scripts/content-sync.mjs"
   },
   "engines": {
     "node": ">=18"
@@ -24,6 +25,7 @@
     "scripts",
     "examples",
     "docs",
+    "ecosystem.config.cjs",
     "README.md",
     "LICENSE"
   ]

--- a/scripts/content-sync.mjs
+++ b/scripts/content-sync.mjs
@@ -1,0 +1,491 @@
+#!/usr/bin/env node
+// Content-sync: keep pinned tier-b cards in lockstep with the GitHub backup
+// repo `agent-working-memory-content`. One-way push only (local → backup).
+//
+// Surfaces:
+//   - dry-run: print deterministic per-card action lines, exit 0, no commits.
+//   - full run: stage diffs, commit, push to origin. Exits non-zero on push
+//     failure and writes a single-line failure record (last-error-only) to
+//     <clone>/.last-sync-error.log.
+//   - npm run sync: same logic as the cron path (B5).
+//
+// Determinism contract:
+//   - Action lines are sorted by relative path (forward-slash separators).
+//   - Action prefixes: ADD, UPDATE, DELETE, SKIP-FILTER (with reason token).
+//   - Commit subject prefix is fixed ("chore(content-sync): ...") so
+//     downstream tooling can grep without depending on the sync's body.
+//
+// Idempotency:
+//   - UPDATE is detected via SHA-256 of the source vs. destination bytes.
+//     Equal bytes → SKIP (no action line emitted; the file is already in
+//     sync). This keeps a second consecutive run with no local delta from
+//     producing a fresh commit (B2).
+//
+// Test seams (env vars; production omits all of them):
+//   WORKING_MEMORY_ROOT          — root of tier-b (default $HOME/.claude/agent-working-memory)
+//   CONTENT_REPO_CLONE           — local clone path of the content repo
+//   CONTENT_REPO_REMOTE          — git remote URL override (B10 — exercises
+//                                  the failure path in tests)
+//   CONTENT_REPO_BRANCH          — target branch (default "main")
+//   CONTENT_SYNC_SKIP_PUSH       — "1" to skip push (used by the e2e test
+//                                  when no remote is reachable)
+//   CONTENT_SYNC_AUTHOR_NAME     — git author override
+//   CONTENT_SYNC_AUTHOR_EMAIL    — git author override
+//
+// Flags:
+//   --dry-run            — print actions, no writes, no commits
+//   --verbose            — emit extra debug lines on stderr
+//   --root PATH          — override WORKING_MEMORY_ROOT for one run
+//   --clone PATH         — override CONTENT_REPO_CLONE for one run
+//
+// Exit codes:
+//   0  — success (dry-run, no-op, or successful push)
+//   1  — sync failure (write failure record before exiting)
+//   2  — bad usage / argument error
+
+import {
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+  mkdirSync,
+  existsSync,
+  statSync,
+  rmSync,
+  copyFileSync,
+} from "node:fs";
+import { join, relative, dirname, sep } from "node:path";
+import { homedir } from "node:os";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { parseCard } from "../src/card-shape.mjs";
+import { shouldInclude } from "./lib/content-filter.mjs";
+
+const COMMIT_SUBJECT_PREFIX = "chore(content-sync): sync pinned cards";
+const FAILURE_RECORD_NAME = ".last-sync-error.log";
+const DEFAULT_BRANCH = "main";
+const DEFAULT_RETRY_BUDGET = 3;
+
+// ---------------------------------------------------------------------------
+// CLI parsing.
+
+function parseArgs(argv) {
+  const out = { dryRun: false, verbose: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--dry-run") out.dryRun = true;
+    else if (a === "--verbose") out.verbose = true;
+    else if (a === "--root") out.root = argv[++i];
+    else if (a === "--clone") out.clone = argv[++i];
+    else if (a === "--help" || a === "-h") out.help = true;
+    else {
+      out.unknownArg = a;
+    }
+  }
+  return out;
+}
+
+function usage() {
+  return [
+    "usage: content-sync [--dry-run] [--verbose] [--root PATH] [--clone PATH]",
+    "  --dry-run    print actions, no writes, no commits",
+    "  --verbose    emit extra debug lines on stderr",
+    "  --root PATH  override WORKING_MEMORY_ROOT for one run",
+    "  --clone PATH override CONTENT_REPO_CLONE for one run",
+    "",
+    "env:",
+    "  WORKING_MEMORY_ROOT         tier-b root",
+    "  CONTENT_REPO_CLONE          local clone of the content repo",
+    "  CONTENT_REPO_REMOTE         remote URL override",
+    "  CONTENT_REPO_BRANCH         target branch (default main)",
+    "  CONTENT_SYNC_SKIP_PUSH=1    skip the push step (test seam)",
+    "",
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Path resolution.
+
+function resolveRoot(arg) {
+  if (arg) return arg;
+  if (process.env.WORKING_MEMORY_ROOT) return process.env.WORKING_MEMORY_ROOT;
+  return join(homedir(), ".claude", "agent-working-memory");
+}
+
+function resolveClone(arg) {
+  if (arg) return arg;
+  if (process.env.CONTENT_REPO_CLONE) return process.env.CONTENT_REPO_CLONE;
+  return join(homedir(), ".claude", "agent-working-memory", "content-repo-clone");
+}
+
+// ---------------------------------------------------------------------------
+// Sources: enumerate tier-b cards relative to tier-b root, applying the
+// content-filter predicate.
+
+function listLocalSources(tierBRoot) {
+  const out = []; // { relPath (forward-slash, tier-b-relative), absPath, included, reason }
+  const topicsDir = join(tierBRoot, "topics");
+  if (!existsSync(topicsDir)) return out;
+
+  function walk(dir) {
+    let entries;
+    try { entries = readdirSync(dir); } catch { return; }
+    for (const name of entries.sort()) {
+      const full = join(dir, name);
+      let st;
+      try { st = statSync(full); } catch { continue; }
+      if (st.isDirectory()) walk(full);
+      else if (st.isFile()) {
+        const rel = relative(tierBRoot, full).split(sep).join("/");
+        let parsed = null;
+        if (rel.endsWith(".md")) {
+          try {
+            const text = readFileSync(full, "utf8");
+            parsed = parseCard(text);
+          } catch {
+            parsed = { ok: false, reason: "read-error" };
+          }
+        }
+        const decision = shouldInclude(rel, parsed);
+        out.push({
+          relPath: rel,
+          absPath: full,
+          included: decision.included,
+          reason: decision.reason,
+        });
+      }
+    }
+  }
+  walk(topicsDir);
+  out.sort((a, b) => (a.relPath < b.relPath ? -1 : a.relPath > b.relPath ? 1 : 0));
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Destinations: enumerate tracked card files in the content-repo clone so we
+// can compute DELETE actions for cards that disappeared locally.
+
+function listClonedDests(cloneRoot) {
+  const out = new Map(); // relPath → absPath
+  const tierBDir = join(cloneRoot, "tier-b");
+  if (!existsSync(tierBDir)) return out;
+
+  function walk(dir) {
+    let entries;
+    try { entries = readdirSync(dir); } catch { return; }
+    for (const name of entries.sort()) {
+      const full = join(dir, name);
+      let st;
+      try { st = statSync(full); } catch { continue; }
+      if (st.isDirectory()) walk(full);
+      else if (st.isFile() && name.endsWith(".md")) {
+        const rel = relative(tierBDir, full).split(sep).join("/");
+        out.set(rel, full);
+      }
+    }
+  }
+  walk(tierBDir);
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Hash-based edit detection.
+
+function fileHash(path) {
+  try {
+    return createHash("sha256").update(readFileSync(path)).digest("hex");
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Plan: compute the set of actions from local + cloned state. Pure-ish (only
+// reads files for hash compare; no writes). Returns deterministic-ordered
+// actions.
+
+export function computePlan(tierBRoot, cloneRoot) {
+  const sources = listLocalSources(tierBRoot);
+  const dests = listClonedDests(cloneRoot);
+
+  const actions = []; // { kind, relPath, reason? }
+
+  // Forward direction: source → dest.
+  for (const src of sources) {
+    if (!src.included) {
+      actions.push({ kind: "SKIP-FILTER", relPath: src.relPath, reason: src.reason });
+      continue;
+    }
+    const destAbs = join(cloneRoot, "tier-b", src.relPath);
+    if (!dests.has(src.relPath)) {
+      actions.push({ kind: "ADD", relPath: src.relPath });
+    } else {
+      const sh = fileHash(src.absPath);
+      const dh = fileHash(destAbs);
+      if (sh !== null && dh !== null && sh !== dh) {
+        actions.push({ kind: "UPDATE", relPath: src.relPath });
+      }
+      // equal hashes → no action (idempotent path).
+    }
+  }
+
+  // Reverse direction: dest → source. Anything in the clone that has no
+  // corresponding *included* source is a DELETE candidate.
+  const includedRels = new Set(sources.filter((s) => s.included).map((s) => s.relPath));
+  for (const rel of [...dests.keys()].sort()) {
+    if (!includedRels.has(rel)) {
+      actions.push({ kind: "DELETE", relPath: rel });
+    }
+  }
+
+  // Final sort: by (relPath, kind) for stable cross-run output. ADD/UPDATE/
+  // DELETE appear interleaved with SKIP-FILTER lines, but the ordering is
+  // deterministic.
+  actions.sort((a, b) => {
+    if (a.relPath !== b.relPath) return a.relPath < b.relPath ? -1 : 1;
+    return a.kind < b.kind ? -1 : a.kind > b.kind ? 1 : 0;
+  });
+  return actions;
+}
+
+// ---------------------------------------------------------------------------
+// Apply plan to the local clone working tree. Returns the list of touched
+// rel-paths (so the caller can `git add` them explicitly — never `git add -A`).
+
+function applyPlan(actions, tierBRoot, cloneRoot, opts) {
+  const touched = [];
+  for (const a of actions) {
+    if (a.kind === "SKIP-FILTER") continue;
+    const destAbs = join(cloneRoot, "tier-b", a.relPath);
+    if (a.kind === "ADD" || a.kind === "UPDATE") {
+      const srcAbs = join(tierBRoot, a.relPath);
+      mkdirSync(dirname(destAbs), { recursive: true });
+      copyFileSync(srcAbs, destAbs);
+      touched.push(join("tier-b", a.relPath).split(sep).join("/"));
+    } else if (a.kind === "DELETE") {
+      try { rmSync(destAbs, { force: true }); } catch { /* tolerate */ }
+      touched.push(join("tier-b", a.relPath).split(sep).join("/"));
+    }
+  }
+  return touched;
+}
+
+// ---------------------------------------------------------------------------
+// Git ops on the clone. Each call shells out with execFileSync so a non-zero
+// exit propagates up as a thrown Error (caught by main()).
+
+function git(cloneRoot, args, opts = {}) {
+  return execFileSync("git", args, {
+    cwd: cloneRoot,
+    encoding: "utf8",
+    stdio: opts.stdio || ["ignore", "pipe", "pipe"],
+    env: { ...process.env, ...(opts.env || {}) },
+  });
+}
+
+function ensureClone(cloneRoot, remoteUrl, branch) {
+  if (existsSync(join(cloneRoot, ".git"))) return;
+  mkdirSync(dirname(cloneRoot), { recursive: true });
+  execFileSync("git", ["clone", "--branch", branch, remoteUrl, cloneRoot], {
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf8",
+  });
+}
+
+function pullRebaseWithRetry(cloneRoot, branch, budget, log) {
+  let lastErr = null;
+  for (let attempt = 1; attempt <= budget; attempt++) {
+    try {
+      git(cloneRoot, ["pull", "--rebase", "origin", branch]);
+      return;
+    } catch (err) {
+      lastErr = err;
+      log(`pull --rebase attempt ${attempt}/${budget} failed: ${err.message?.split("\n")[0]}`);
+    }
+  }
+  throw lastErr || new Error("pull --rebase failed after retries");
+}
+
+// ---------------------------------------------------------------------------
+// Failure record: single-line, last-error-only, overwritten each run.
+
+function writeFailureRecord(cloneRoot, errClass, message) {
+  try {
+    mkdirSync(cloneRoot, { recursive: true });
+  } catch { /* tolerate */ }
+  const ts = new Date().toISOString();
+  const line = `${ts} class=${errClass} message=${message.replace(/\s+/g, " ").slice(0, 500)}\n`;
+  try {
+    writeFileSync(join(cloneRoot, FAILURE_RECORD_NAME), line, "utf8");
+  } catch { /* last-resort silent — we're already in failure path */ }
+}
+
+function clearFailureRecord(cloneRoot) {
+  try {
+    const p = join(cloneRoot, FAILURE_RECORD_NAME);
+    if (existsSync(p)) rmSync(p, { force: true });
+  } catch { /* tolerate */ }
+}
+
+// ---------------------------------------------------------------------------
+// Render dry-run output. One line per action; SKIP-FILTER carries reason.
+
+function renderDryRun(actions) {
+  const lines = [];
+  for (const a of actions) {
+    if (a.kind === "SKIP-FILTER") {
+      lines.push(`SKIP-FILTER ${a.relPath} reason=${a.reason}`);
+    } else {
+      lines.push(`${a.kind} ${a.relPath}`);
+    }
+  }
+  return lines.join("\n") + (lines.length ? "\n" : "");
+}
+
+// ---------------------------------------------------------------------------
+// Main programmatic entry. Returns { exitCode, actions, touched, ... }.
+
+export async function runSync(opts = {}) {
+  const tierBRootArg = opts.root ? join(opts.root, "tier-b") : null;
+  const tierBRoot = tierBRootArg || join(resolveRoot(), "tier-b");
+  const cloneRoot = resolveClone(opts.clone);
+  const remoteUrl =
+    opts.remote ||
+    process.env.CONTENT_REPO_REMOTE ||
+    "https://github.com/ziyilam3999/agent-working-memory-content.git";
+  const branch = process.env.CONTENT_REPO_BRANCH || DEFAULT_BRANCH;
+  const skipPush = process.env.CONTENT_SYNC_SKIP_PUSH === "1" || opts.skipPush === true;
+  const retryBudget = opts.retryBudget || DEFAULT_RETRY_BUDGET;
+  const verbose = opts.verbose === true;
+
+  const log = (msg) => {
+    if (verbose) process.stderr.write(`content-sync: ${msg}\n`);
+  };
+
+  if (opts.dryRun) {
+    const actions = computePlan(tierBRoot, cloneRoot);
+    return { exitCode: 0, actions, dryRun: true, output: renderDryRun(actions) };
+  }
+
+  // Real run: ensure clone exists, pull, apply, commit, push.
+  try {
+    ensureClone(cloneRoot, remoteUrl, branch);
+    log(`clone at ${cloneRoot} (branch ${branch})`);
+
+    // Configure local author so commits don't depend on global git config.
+    if (process.env.CONTENT_SYNC_AUTHOR_NAME) {
+      git(cloneRoot, ["config", "user.name", process.env.CONTENT_SYNC_AUTHOR_NAME]);
+    }
+    if (process.env.CONTENT_SYNC_AUTHOR_EMAIL) {
+      git(cloneRoot, ["config", "user.email", process.env.CONTENT_SYNC_AUTHOR_EMAIL]);
+    }
+
+    if (!skipPush) {
+      pullRebaseWithRetry(cloneRoot, branch, retryBudget, log);
+    }
+
+    const actions = computePlan(tierBRoot, cloneRoot);
+    const realActions = actions.filter((a) => a.kind !== "SKIP-FILTER");
+    const touched = applyPlan(actions, tierBRoot, cloneRoot, opts);
+
+    if (touched.length === 0) {
+      log("no delta — idempotent no-op");
+      clearFailureRecord(cloneRoot);
+      return { exitCode: 0, actions, touched, committed: false, pushed: false };
+    }
+
+    // Stage explicitly — never `git add -A` or `.`.
+    for (const path of touched) {
+      git(cloneRoot, ["add", "--", path]);
+    }
+
+    // Detect whether anything is actually staged (e.g. a DELETE on a path
+    // that didn't exist could leave us with nothing to commit).
+    let hasStaged = true;
+    try {
+      git(cloneRoot, ["diff", "--cached", "--quiet"]);
+      hasStaged = false;
+    } catch {
+      hasStaged = true;
+    }
+    if (!hasStaged) {
+      log("staged set is empty — idempotent no-op");
+      clearFailureRecord(cloneRoot);
+      return { exitCode: 0, actions, touched, committed: false, pushed: false };
+    }
+
+    const subject = `${COMMIT_SUBJECT_PREFIX} (${realActions.length} action${realActions.length === 1 ? "" : "s"})`;
+    git(cloneRoot, ["commit", "-m", subject]);
+    log(`committed: ${subject}`);
+
+    let pushed = false;
+    if (!skipPush) {
+      git(cloneRoot, ["push", "origin", branch]);
+      pushed = true;
+      log(`pushed to origin/${branch}`);
+    }
+
+    clearFailureRecord(cloneRoot);
+    return { exitCode: 0, actions, touched, committed: true, pushed, subject };
+  } catch (err) {
+    const msg = (err && err.message) || String(err);
+    const errClass = classifyError(err);
+    writeFailureRecord(cloneRoot, errClass, msg);
+    return { exitCode: 1, error: msg, errClass };
+  }
+}
+
+function classifyError(err) {
+  const msg = ((err && err.message) || "").toLowerCase();
+  if (msg.includes("could not resolve host") || msg.includes("network")) return "network";
+  if (msg.includes("authentication") || msg.includes("permission denied")) return "auth";
+  if (msg.includes("non-fast-forward") || msg.includes("rejected")) return "push-rejected";
+  if (msg.includes("pull --rebase")) return "rebase-failed";
+  return "git";
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry.
+
+export async function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    process.stdout.write(usage());
+    return 0;
+  }
+  if (args.unknownArg) {
+    process.stderr.write(`content-sync: unknown arg: ${args.unknownArg}\n${usage()}`);
+    return 2;
+  }
+  const result = await runSync({
+    dryRun: args.dryRun,
+    verbose: args.verbose,
+    root: args.root,
+    clone: args.clone,
+  });
+  if (result.dryRun) {
+    process.stdout.write(result.output);
+    return result.exitCode;
+  }
+  if (result.exitCode === 0) {
+    if (result.committed) {
+      process.stdout.write(`content-sync: ${result.subject}\n`);
+    } else {
+      process.stdout.write("content-sync: no delta\n");
+    }
+  } else {
+    process.stderr.write(`content-sync: FAILED class=${result.errClass} ${result.error}\n`);
+  }
+  return result.exitCode;
+}
+
+const invokedAsCli =
+  import.meta.url === `file://${process.argv[1]}` ||
+  process.argv[1]?.endsWith("content-sync.mjs");
+if (invokedAsCli) {
+  main()
+    .then((c) => process.exit(c || 0))
+    .catch((e) => {
+      process.stderr.write(`content-sync: unexpected error: ${e.message}\n`);
+      process.exit(1);
+    });
+}

--- a/scripts/lib/content-filter.mjs
+++ b/scripts/lib/content-filter.mjs
@@ -1,0 +1,43 @@
+// Content-filter predicate.
+//
+// Decides which tier-b cards belong in the public-but-private content-repo
+// backup. Phase 1 of the card-tracking strategy: only PINNED cards under
+// `tier-b/topics/` are tracked. Non-pinned cards stay local-only until a
+// future phase introduces middle-ground triage.
+//
+// Inputs:
+//   - relPath: tier-b-relative path of a card file (e.g.
+//     "topics/memory-architecture/2026-04-15-foo.md"). Forward-slash
+//     separators expected; callers normalize before calling.
+//   - parsed: result of parseCard(text) from src/card-shape.mjs. The filter
+//     reads parsed.front.pinned only (string "true"/"false") so it remains
+//     decoupled from the validator's evolving schema.
+//
+// Output: { included: boolean, reason: string }
+//   reason is a short machine-readable token suitable for dry-run output:
+//     "pinned"            — included
+//     "non-pinned"        — excluded (most common reason)
+//     "not-card"          — excluded (frontmatter parse failed)
+//     "outside-topics"    — excluded (path is not under topics/)
+//     "non-md"            — excluded (path doesn't end .md)
+//
+// Determinism: pure function. No I/O. No clock.
+
+const TOPICS_PREFIX = "topics/";
+
+export function shouldInclude(relPath, parsed) {
+  if (!relPath.endsWith(".md")) {
+    return { included: false, reason: "non-md" };
+  }
+  if (!relPath.startsWith(TOPICS_PREFIX)) {
+    return { included: false, reason: "outside-topics" };
+  }
+  if (!parsed || !parsed.ok) {
+    return { included: false, reason: "not-card" };
+  }
+  const pinned = parsed.front && parsed.front.pinned === "true";
+  if (!pinned) {
+    return { included: false, reason: "non-pinned" };
+  }
+  return { included: true, reason: "pinned" };
+}

--- a/src/refresh.mjs
+++ b/src/refresh.mjs
@@ -1,9 +1,23 @@
 // Refresh: rebuild tier-a.md from the tier-b tree under $WORKING_MEMORY_ROOT.
 // Usage:
 //   node src/refresh.mjs [--root PATH] [--budget BYTES] [--dry-run]
+//                        [--status-fragment PATH]
 // If --root is omitted, uses $WORKING_MEMORY_ROOT or the default under $HOME/.claude/.
+//
+// Memory-liveness fragment include (PR-B AC B7):
+//   refresh() also consumes a Cairn-written status fragment (PR A's
+//   producer at cairn/bin/cairn-liveness.mjs) and embeds it in tier-a.md
+//   with four-branch graceful behavior:
+//     (a) present and fresh (anchor + mtime within freshness window) → embed
+//     (b) absent → no embed, no error
+//     (c) malformed (anchor missing) → no embed, optional one-line note
+//     (d) stale (anchor present, mtime older than window) → embed WITH age
+//         annotation
+//
+// The fragment path defaults to $CAIRN_STATUS_FRAGMENT or
+// $HOME/.claude/cairn/status-fragment.md, matching PR A's writer.
 
-import { writeFileSync, mkdirSync } from "node:fs";
+import { writeFileSync, mkdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { loadCards, compact, DEFAULT_BUDGET } from "./compact.mjs";
@@ -16,6 +30,15 @@ import { loadCards, compact, DEFAULT_BUDGET } from "./compact.mjs";
 // misrouting writes. See plan:
 //   forge-harness/.ai-workspace/plans/2026-04-19-memory-cli-home-leak-fix.md
 const UNEXPANDED_TOKEN_RE = /\$\{?[A-Za-z_][A-Za-z0-9_]*\}?/;
+
+// Memory-liveness fragment freshness window. PR A's H7 cron fires every 6h
+// and its heartbeat-reader uses an 8h window — adopt the same value here so
+// "fresh by Cairn's lights" and "fresh by the consumer's lights" agree.
+const FRAGMENT_FRESHNESS_MS = 8 * 60 * 60 * 1000;
+
+// Stable anchor heading the producer (PR A) writes; PR-B's consumer asserts
+// it's present before embedding. Missing → malformed branch.
+const FRAGMENT_HEADING = "## Memory liveness";
 
 function assertExpandedPath(candidate, source) {
   const match = UNEXPANDED_TOKEN_RE.exec(candidate);
@@ -38,16 +61,104 @@ export function resolveRoot(argRoot) {
   return join(homedir(), ".claude", "agent-working-memory");
 }
 
-export function refresh({ root, budget = DEFAULT_BUDGET, dryRun = false } = {}) {
+function resolveStatusFragmentPath(arg) {
+  if (arg) return arg;
+  if (process.env.CAIRN_STATUS_FRAGMENT) return process.env.CAIRN_STATUS_FRAGMENT;
+  return join(homedir(), ".claude", "cairn", "status-fragment.md");
+}
+
+/**
+ * Read the Cairn status fragment if present and classify it across the four
+ * B7 branches. Pure: no writes; returns a plain object.
+ *
+ * Returns one of:
+ *   { branch: "absent" }                              — file does not exist
+ *   { branch: "malformed" }                           — anchor heading missing
+ *   { branch: "fresh", body }                         — anchor + within window
+ *   { branch: "stale",  body, ageMs }                 — anchor + outside window
+ */
+export function classifyStatusFragment(fragmentPath, now = Date.now(), windowMs = FRAGMENT_FRESHNESS_MS) {
+  let st;
+  try {
+    st = statSync(fragmentPath);
+  } catch {
+    return { branch: "absent" };
+  }
+  let body;
+  try {
+    body = readFileSync(fragmentPath, "utf8");
+  } catch {
+    return { branch: "absent" };
+  }
+  if (!body.includes(FRAGMENT_HEADING)) {
+    return { branch: "malformed" };
+  }
+  const ageMs = now - st.mtimeMs;
+  if (ageMs > windowMs) {
+    return { branch: "stale", body, ageMs };
+  }
+  return { branch: "fresh", body };
+}
+
+function formatAgeShort(ageMs) {
+  if (ageMs == null || ageMs < 0) return "0s";
+  const sec = Math.floor(ageMs / 1000);
+  if (sec < 60) return `${sec}s`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m`;
+  const hr = Math.floor(min / 60);
+  if (hr < 48) return `${hr}h`;
+  const day = Math.floor(hr / 24);
+  return `${day}d`;
+}
+
+/**
+ * Render the memory-liveness section to append to tier-a.md, given a fragment
+ * classification. Returns "" for the absent branch (caller emits nothing).
+ * Branch-(c) malformed appends a single optional note line so an operator
+ * inspecting tier-a.md can tell the difference between "absent" and "Cairn
+ * wrote junk" without having to open the fragment file.
+ */
+export function renderLivenessSection(classification) {
+  if (classification.branch === "absent") return "";
+  if (classification.branch === "malformed") {
+    return "\n_memory-liveness: malformed_\n";
+  }
+  if (classification.branch === "fresh") {
+    return "\n" + classification.body.trimEnd() + "\n";
+  }
+  // stale — embed body but tag the heading with an age annotation so
+  // consumers see at a glance the panel is past its freshness window.
+  const ageStr = formatAgeShort(classification.ageMs);
+  const annotated = classification.body.replace(
+    FRAGMENT_HEADING,
+    `${FRAGMENT_HEADING} (stale — ${ageStr} old)`,
+  );
+  return "\n" + annotated.trimEnd() + "\n";
+}
+
+export function refresh({ root, budget = DEFAULT_BUDGET, dryRun = false, statusFragmentPath } = {}) {
   const tierBRoot = join(root, "tier-b");
   const cards = loadCards(tierBRoot);
   const tierA = compact(cards, { budget });
+
+  const fragPath = resolveStatusFragmentPath(statusFragmentPath);
+  const classification = classifyStatusFragment(fragPath);
+  const livenessSection = renderLivenessSection(classification);
+  const finalContent = tierA + livenessSection;
+
   const outPath = join(root, "tier-a.md");
   if (!dryRun) {
     mkdirSync(root, { recursive: true });
-    writeFileSync(outPath, tierA, "utf8");
+    writeFileSync(outPath, finalContent, "utf8");
   }
-  return { outPath, bytes: Buffer.byteLength(tierA, "utf8"), cardCount: cards.length, content: tierA };
+  return {
+    outPath,
+    bytes: Buffer.byteLength(finalContent, "utf8"),
+    cardCount: cards.length,
+    content: finalContent,
+    livenessBranch: classification.branch,
+  };
 }
 
 function parseArgs(argv) {
@@ -57,6 +168,7 @@ function parseArgs(argv) {
     if (a === "--root") out.root = argv[++i];
     else if (a === "--budget") out.budget = parseInt(argv[++i], 10);
     else if (a === "--dry-run") out.dryRun = true;
+    else if (a === "--status-fragment") out.statusFragmentPath = argv[++i];
   }
   return out;
 }
@@ -64,6 +176,11 @@ function parseArgs(argv) {
 if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith("refresh.mjs")) {
   const args = parseArgs(process.argv.slice(2));
   const root = resolveRoot(args.root);
-  const res = refresh({ root, budget: args.budget, dryRun: args.dryRun });
-  process.stdout.write(`refreshed ${res.outPath} (${res.bytes} bytes, ${res.cardCount} cards)\n`);
+  const res = refresh({
+    root,
+    budget: args.budget,
+    dryRun: args.dryRun,
+    statusFragmentPath: args.statusFragmentPath,
+  });
+  process.stdout.write(`refreshed ${res.outPath} (${res.bytes} bytes, ${res.cardCount} cards, liveness=${res.livenessBranch})\n`);
 }

--- a/tests/content-sync.test.mjs
+++ b/tests/content-sync.test.mjs
@@ -11,7 +11,8 @@
 //   - B7 a/b/c/d freshness branches for src/refresh.mjs fragment include
 //
 // All tests use isolated tmp dirs and the env-var seams documented in
-// scripts/content-sync.mjs and src/refresh.mjs. None touch ~/.claude/.
+// scripts/content-sync.mjs and src/refresh.mjs. None touch the user's
+// real Claude home directory.
 
 import { test } from "node:test";
 import assert from "node:assert/strict";

--- a/tests/content-sync.test.mjs
+++ b/tests/content-sync.test.mjs
@@ -1,0 +1,400 @@
+// Content-sync tests.
+//
+// Covers the four PR-B-mandated new cases plus an end-to-end fixture sync:
+//   - filter predicate (pinned vs. non-pinned, non-md, outside-topics)
+//   - hash-based edit detection (UPDATE only emitted on byte change)
+//   - idempotency (second run with no delta produces zero new commits)
+//   - non-pinned exclusion (skip lines render with reason=non-pinned)
+//   - end-to-end (B3): seed pinned card → run sync → assert exit 0,
+//     file-at-expected-path, one new commit with stable subject prefix
+//   - B3b push parity (no local-only commits remain after run)
+//   - B7 a/b/c/d freshness branches for src/refresh.mjs fragment include
+//
+// All tests use isolated tmp dirs and the env-var seams documented in
+// scripts/content-sync.mjs and src/refresh.mjs. None touch ~/.claude/.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { execFileSync } from "node:child_process";
+
+import { computePlan, runSync } from "../scripts/content-sync.mjs";
+import { shouldInclude } from "../scripts/lib/content-filter.mjs";
+import { parseCard } from "../src/card-shape.mjs";
+import { refresh } from "../src/refresh.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURES_DIR = join(__dirname, "fixtures", "content-sync");
+
+// ---------------------------------------------------------------------------
+// Helpers.
+
+function makeCard({ id, topic, title, pinned, created = "2026-04-25" }) {
+  return [
+    "---",
+    `id: ${id}`,
+    `topic: ${topic}`,
+    `title: ${title}`,
+    `created: ${created}`,
+    `pinned: ${pinned}`,
+    "tags: []",
+    "---",
+    "",
+    "## Decision",
+    `Body for ${id}.`,
+    "",
+  ].join("\n");
+}
+
+function seedTierB(tierBRoot, cards) {
+  for (const c of cards) {
+    const dir = join(tierBRoot, "topics", c.topic);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, `${c.id}.md`), makeCard(c), "utf8");
+  }
+}
+
+// Make a tmp dir, then init a bare-equivalent local `origin` git repo so
+// `git clone` succeeds without network access. Returns { remoteUrl, cloneRoot }.
+function makeLocalRemote(tmpRoot) {
+  const bare = join(tmpRoot, "remote.git");
+  mkdirSync(bare, { recursive: true });
+  execFileSync("git", ["init", "--bare", "--initial-branch=main", bare], { stdio: "ignore" });
+
+  // Seed the bare repo with one initial commit on main so clone has a target.
+  const seed = join(tmpRoot, "seed");
+  mkdirSync(seed, { recursive: true });
+  execFileSync("git", ["init", "--initial-branch=main", seed], { stdio: "ignore" });
+  execFileSync("git", ["config", "user.email", "test@test"], { cwd: seed, stdio: "ignore" });
+  execFileSync("git", ["config", "user.name", "Test"], { cwd: seed, stdio: "ignore" });
+  writeFileSync(join(seed, "README.md"), "# content\n", "utf8");
+  execFileSync("git", ["add", "README.md"], { cwd: seed, stdio: "ignore" });
+  execFileSync("git", ["commit", "-m", "initial"], { cwd: seed, stdio: "ignore" });
+  execFileSync("git", ["remote", "add", "origin", bare], { cwd: seed, stdio: "ignore" });
+  execFileSync("git", ["push", "origin", "main"], { cwd: seed, stdio: "ignore" });
+
+  return { remoteUrl: bare };
+}
+
+// ---------------------------------------------------------------------------
+// 1. Filter predicate.
+
+test("filter: pinned card under topics/ is included", () => {
+  const card = makeCard({ id: "a", topic: "demo", title: "x", pinned: true });
+  const parsed = parseCard(card);
+  const decision = shouldInclude("topics/demo/a.md", parsed);
+  assert.equal(decision.included, true);
+  assert.equal(decision.reason, "pinned");
+});
+
+test("filter: non-pinned card excluded with reason=non-pinned", () => {
+  const card = makeCard({ id: "b", topic: "demo", title: "x", pinned: false });
+  const parsed = parseCard(card);
+  const decision = shouldInclude("topics/demo/b.md", parsed);
+  assert.equal(decision.included, false);
+  assert.equal(decision.reason, "non-pinned");
+});
+
+test("filter: non-md file excluded with reason=non-md", () => {
+  const decision = shouldInclude("topics/demo/notes.txt", null);
+  assert.equal(decision.included, false);
+  assert.equal(decision.reason, "non-md");
+});
+
+test("filter: file outside topics/ excluded", () => {
+  const card = makeCard({ id: "c", topic: "demo", title: "x", pinned: true });
+  const parsed = parseCard(card);
+  const decision = shouldInclude("scratch/c.md", parsed);
+  assert.equal(decision.included, false);
+  assert.equal(decision.reason, "outside-topics");
+});
+
+// ---------------------------------------------------------------------------
+// 2. Hash-based edit detection.
+
+test("hash-edit: identical bytes produce no UPDATE action", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "awm-sync-hash-"));
+  const root = join(tmp, "wm");
+  const clone = join(tmp, "clone");
+  mkdirSync(join(root, "tier-b"), { recursive: true });
+  mkdirSync(join(clone, "tier-b"), { recursive: true });
+  seedTierB(join(root, "tier-b"), [{ id: "h1", topic: "demo", title: "x", pinned: true }]);
+  // Mirror the same bytes into clone.
+  const rel = "topics/demo/h1.md";
+  const body = readFileSync(join(root, "tier-b", rel), "utf8");
+  mkdirSync(join(clone, "tier-b", "topics", "demo"), { recursive: true });
+  writeFileSync(join(clone, "tier-b", rel), body, "utf8");
+
+  const plan = computePlan(join(root, "tier-b"), clone);
+  const realActions = plan.filter((a) => a.kind !== "SKIP-FILTER");
+  assert.equal(realActions.length, 0, "no real actions on identical bytes");
+});
+
+test("hash-edit: byte change produces UPDATE", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "awm-sync-hash2-"));
+  const root = join(tmp, "wm");
+  const clone = join(tmp, "clone");
+  mkdirSync(join(root, "tier-b"), { recursive: true });
+  mkdirSync(join(clone, "tier-b"), { recursive: true });
+  seedTierB(join(root, "tier-b"), [{ id: "h2", topic: "demo", title: "x", pinned: true }]);
+  // Stale older copy in clone.
+  const rel = "topics/demo/h2.md";
+  mkdirSync(join(clone, "tier-b", "topics", "demo"), { recursive: true });
+  writeFileSync(
+    join(clone, "tier-b", rel),
+    makeCard({ id: "h2", topic: "demo", title: "OLD-title", pinned: true }),
+    "utf8",
+  );
+
+  const plan = computePlan(join(root, "tier-b"), clone);
+  const updates = plan.filter((a) => a.kind === "UPDATE");
+  assert.equal(updates.length, 1);
+  assert.equal(updates[0].relPath, rel);
+});
+
+// ---------------------------------------------------------------------------
+// 3. Idempotency (no new commits on second run).
+
+test("idempotent: second run with no local delta produces no new commits", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "awm-sync-idem-"));
+  const root = join(tmp, "wm");
+  mkdirSync(join(root, "tier-b"), { recursive: true });
+  seedTierB(join(root, "tier-b"), [{ id: "i1", topic: "demo", title: "x", pinned: true }]);
+
+  const { remoteUrl } = makeLocalRemote(tmp);
+  const clone = join(tmp, "clone");
+
+  const env = {
+    CONTENT_REPO_REMOTE: remoteUrl,
+    CONTENT_REPO_CLONE: clone,
+    CONTENT_REPO_BRANCH: "main",
+    CONTENT_SYNC_AUTHOR_NAME: "Test",
+    CONTENT_SYNC_AUTHOR_EMAIL: "test@test",
+  };
+  const oldEnv = saveEnv(env);
+  applyEnv(env);
+  try {
+    const r1 = await runSync({ root, clone });
+    assert.equal(r1.exitCode, 0);
+    assert.equal(r1.committed, true);
+    const sha1 = execFileSync("git", ["rev-parse", "HEAD"], { cwd: clone, encoding: "utf8" }).trim();
+
+    const r2 = await runSync({ root, clone });
+    assert.equal(r2.exitCode, 0);
+    assert.equal(r2.committed, false, "second run should not commit");
+    const sha2 = execFileSync("git", ["rev-parse", "HEAD"], { cwd: clone, encoding: "utf8" }).trim();
+    assert.equal(sha1, sha2, "HEAD unchanged across runs");
+  } finally {
+    restoreEnv(oldEnv);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 4. Non-pinned exclusion (renders SKIP-FILTER reason=non-pinned in dry-run).
+
+test("non-pinned exclusion: dry-run renders SKIP-FILTER reason=non-pinned", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "awm-sync-skip-"));
+  const root = join(tmp, "wm");
+  mkdirSync(join(root, "tier-b"), { recursive: true });
+  seedTierB(join(root, "tier-b"), [
+    { id: "p1", topic: "demo", title: "pinned", pinned: true },
+    { id: "n1", topic: "demo", title: "loose", pinned: false },
+  ]);
+  const clone = join(tmp, "clone");
+
+  const r = await runSync({ root, clone, dryRun: true });
+  assert.equal(r.exitCode, 0);
+  // ADD for pinned, SKIP-FILTER for non-pinned. Sorted by relPath.
+  assert.match(r.output, /ADD topics\/demo\/p1\.md/);
+  assert.match(r.output, /SKIP-FILTER topics\/demo\/n1\.md reason=non-pinned/);
+});
+
+// ---------------------------------------------------------------------------
+// 5. End-to-end fixture sync (B3 + B3b).
+
+test("e2e: pinned card syncs to clone, exit 0, one commit with stable subject prefix, push parity", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "awm-sync-e2e-"));
+  const root = join(tmp, "wm");
+  mkdirSync(join(root, "tier-b"), { recursive: true });
+  seedTierB(join(root, "tier-b"), [{ id: "e1", topic: "demo", title: "x", pinned: true }]);
+  const { remoteUrl } = makeLocalRemote(tmp);
+  const clone = join(tmp, "clone");
+
+  const env = {
+    CONTENT_REPO_REMOTE: remoteUrl,
+    CONTENT_REPO_CLONE: clone,
+    CONTENT_REPO_BRANCH: "main",
+    CONTENT_SYNC_AUTHOR_NAME: "Test",
+    CONTENT_SYNC_AUTHOR_EMAIL: "test@test",
+  };
+  const oldEnv = saveEnv(env);
+  applyEnv(env);
+  try {
+    const r = await runSync({ root, clone });
+
+    // (a) exit 0
+    assert.equal(r.exitCode, 0);
+    assert.equal(r.committed, true);
+    assert.equal(r.pushed, true);
+
+    // (b) file at expected path
+    const dest = join(clone, "tier-b", "topics", "demo", "e1.md");
+    assert.ok(existsSync(dest), "card landed at expected path");
+
+    // (c) one new commit with stable subject prefix
+    const subject = execFileSync("git", ["log", "-1", "--pretty=%s"], { cwd: clone, encoding: "utf8" }).trim();
+    assert.match(subject, /^chore\(content-sync\): sync pinned cards/);
+
+    // B3b: push parity — clone HEAD matches origin/main.
+    const headSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: clone, encoding: "utf8" }).trim();
+    const remoteSha = execFileSync("git", ["rev-parse", "origin/main"], { cwd: clone, encoding: "utf8" }).trim();
+    assert.equal(headSha, remoteSha, "no local-only commits after sync");
+  } finally {
+    restoreEnv(oldEnv);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 6. B10 — sync failure is observable (exit !=0, single-line failure record).
+
+test("failure: unreachable remote produces exit 1 + single-line failure record", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "awm-sync-fail-"));
+  const root = join(tmp, "wm");
+  mkdirSync(join(root, "tier-b"), { recursive: true });
+  seedTierB(join(root, "tier-b"), [{ id: "f1", topic: "demo", title: "x", pinned: true }]);
+  const clone = join(tmp, "clone");
+  // Bogus remote — clone will fail.
+  const env = {
+    CONTENT_REPO_REMOTE: join(tmp, "does-not-exist.git"),
+    CONTENT_REPO_CLONE: clone,
+    CONTENT_REPO_BRANCH: "main",
+  };
+  const oldEnv = saveEnv(env);
+  applyEnv(env);
+  try {
+    const r = await runSync({ root, clone, retryBudget: 1 });
+    assert.equal(r.exitCode, 1);
+    const recordPath = join(clone, ".last-sync-error.log");
+    assert.ok(existsSync(recordPath), "failure record exists");
+    const body = readFileSync(recordPath, "utf8");
+    const lines = body.split("\n").filter(Boolean);
+    assert.equal(lines.length, 1, "single-line failure record");
+    assert.match(lines[0], /class=/);
+  } finally {
+    restoreEnv(oldEnv);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 7. B7 — refresh.mjs Cairn fragment include, four branches.
+
+function makeFragment({ stale = false } = {}) {
+  const ts = stale ? "2020-01-01T00:00:00Z" : new Date().toISOString();
+  return [
+    "## Memory liveness",
+    "",
+    `_generated: ${ts} from /tmp/heartbeats.log_`,
+    "",
+    "- **ARMED** `h4` — last 2026-04-25T10:00:00Z (1m ago)",
+    "- **ARMED** `h7` — last 2026-04-25T10:00:00Z (1m ago)",
+    "",
+  ].join("\n");
+}
+
+test("B7-(a): present and fresh — tier-a includes the fragment under heading", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "awm-refresh-a-"));
+  const root = join(tmp, "wm");
+  mkdirSync(join(root, "tier-b", "topics", "demo"), { recursive: true });
+  writeFileSync(
+    join(root, "tier-b", "topics", "demo", "x.md"),
+    makeCard({ id: "x", topic: "demo", title: "x", pinned: true }),
+    "utf8",
+  );
+  const fragPath = join(tmp, "fragment.md");
+  writeFileSync(fragPath, makeFragment(), "utf8");
+
+  const r = refresh({ root, statusFragmentPath: fragPath });
+  assert.match(r.content, /## Memory liveness/);
+  assert.match(r.content, /ARMED.*h7/);
+});
+
+test("B7-(b): absent — refresh proceeds, no heading", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "awm-refresh-b-"));
+  const root = join(tmp, "wm");
+  mkdirSync(join(root, "tier-b", "topics", "demo"), { recursive: true });
+  writeFileSync(
+    join(root, "tier-b", "topics", "demo", "x.md"),
+    makeCard({ id: "x", topic: "demo", title: "x", pinned: true }),
+    "utf8",
+  );
+  const fragPath = join(tmp, "does-not-exist.md");
+  const r = refresh({ root, statusFragmentPath: fragPath });
+  assert.ok(!r.content.includes("## Memory liveness"));
+});
+
+test("B7-(c): malformed (anchor missing) — refresh proceeds without malformed embed", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "awm-refresh-c-"));
+  const root = join(tmp, "wm");
+  mkdirSync(join(root, "tier-b", "topics", "demo"), { recursive: true });
+  writeFileSync(
+    join(root, "tier-b", "topics", "demo", "x.md"),
+    makeCard({ id: "x", topic: "demo", title: "x", pinned: true }),
+    "utf8",
+  );
+  const fragPath = join(tmp, "fragment.md");
+  writeFileSync(fragPath, "garbage with no anchor heading\n", "utf8");
+  const r = refresh({ root, statusFragmentPath: fragPath });
+  assert.ok(!r.content.includes("## Memory liveness"));
+  // Optional one-line note is acceptable.
+});
+
+test("B7-(d): stale — fragment embedded with age annotation", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "awm-refresh-d-"));
+  const root = join(tmp, "wm");
+  mkdirSync(join(root, "tier-b", "topics", "demo"), { recursive: true });
+  writeFileSync(
+    join(root, "tier-b", "topics", "demo", "x.md"),
+    makeCard({ id: "x", topic: "demo", title: "x", pinned: true }),
+    "utf8",
+  );
+  const fragPath = join(tmp, "fragment.md");
+  writeFileSync(fragPath, makeFragment({ stale: true }), "utf8");
+  // Force the file mtime to ancient so refresh sees it as stale.
+  const ancient = new Date("2020-01-01T00:00:00Z");
+  const fs = await import("node:fs");
+  fs.utimesSync(fragPath, ancient, ancient);
+
+  const r = refresh({ root, statusFragmentPath: fragPath });
+  assert.match(r.content, /## Memory liveness/);
+  assert.match(r.content, /stale/i);
+});
+
+// ---------------------------------------------------------------------------
+// Env helpers.
+
+function saveEnv(keys) {
+  const out = {};
+  for (const k of Object.keys(keys)) out[k] = process.env[k];
+  return out;
+}
+
+function applyEnv(env) {
+  for (const [k, v] of Object.entries(env)) process.env[k] = v;
+}
+
+function restoreEnv(saved) {
+  for (const [k, v] of Object.entries(saved)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+}

--- a/tests/fixtures/content-sync/README.md
+++ b/tests/fixtures/content-sync/README.md
@@ -1,0 +1,6 @@
+# content-sync test fixtures
+
+Tests under `tests/content-sync.test.mjs` build their tier-b layouts inline
+in tmp dirs so each case is hermetic (the worktree's tier-b is git-ignored
+anyway). This directory exists so the path referenced in the PR plan's B9
+file-touch allowlist resolves on disk; it carries no test data of its own.


### PR DESCRIPTION
## Summary

PR B of the memory-status pass — closes plan `ai-brain/.ai-workspace/plans/2026-04-25-memory-status-pass.md` ACs B1-B10.

- **B1/B2** New `scripts/content-sync.mjs` with deterministic dry-run mode (ADD/UPDATE/DELETE/SKIP-FILTER lines, sorted by path, exit 0). Idempotent: second run with no delta produces zero new commits via SHA-256 hash compare.
- **B3/B3b** End-to-end test seeds a pinned card under temp tier-b, runs sync against an isolated bare-repo target, asserts exit 0 + file-at-expected-path + one commit with stable `chore(content-sync): sync pinned cards` subject prefix + push parity with origin.
- **B4** Test count 15 → 29 (floor was 19). Four new cases per AC: filter, hash-edit detection, idempotency, non-pinned exclusion. Plus end-to-end, failure-observability, and B7 a/b/c/d fragment-include branches.
- **B5** `npm run sync` registered (same code path as cron).
- **B6** NEW `ecosystem.config.cjs` — one PM2 app `working-memory-content-sync`, daily 04:30 cron, staggered after ai-brain's H5/H6.
- **B7** `src/refresh.mjs` consumes the Cairn status fragment (PR A producer, ai-brain #522) and embeds the `## Memory liveness` panel in tier-a.md. Four-branch graceful behavior — fresh / absent / malformed / stale. Freshness window 8h, matching H7's cron cadence.
- **B9 allowlist** Diff touches only: `CHANGELOG.md`, `docs/integration.md`, `ecosystem.config.cjs`, `package.json`, `scripts/content-sync.mjs`, `scripts/lib/content-filter.mjs`, `src/refresh.mjs`, `tests/content-sync.test.mjs`, `tests/fixtures/content-sync/`.
- **B10** Failure path observable: exit non-zero + single-line record at `<clone>/.last-sync-error.log` (timestamp + error class). `git pull --rebase` retry budget bounded to 3.

Phase 1 of the card-tracking strategy: only **pinned** cards under `tier-b/topics/` sync. Non-pinned cards stay local-only.

Bumps to **0.2.0**.

## Test plan

- [x] `npm test` passes — 29/29 (15 baseline + 14 new)
- [x] `npm run hygiene` clean
- [x] `node scripts/content-sync.mjs --dry-run` against a seeded fixture: deterministic output, exit 0, sorted by path
- [x] `git diff origin/main --name-only` matches B9 allowlist exactly (9 files)
- [x] No `git add -A` or `.` — per-file staging
- [x] Mailbox heads-up sent to clever-bob per shared-worktree rule #11