### PR TITLE
fix: polish: classifyError 'rebase-failed' token coverage (#21)

### DIFF
--- a/scripts/content-sync.mjs
+++ b/scripts/content-sync.mjs
@@ -302,7 +302,8 @@ function pullRebaseWithRetry(cloneRoot, branch, budget, log) {
       log(`pull --rebase attempt ${attempt}/${budget} failed: ${err.message?.split("\n")[0]}`);
     }
   }
-  throw lastErr || new Error("pull --rebase failed after retries");
+  if (lastErr) throw new Error(`rebase-failed: ${lastErr.message}`);
+  throw new Error("rebase-failed: pull --rebase failed after retries");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #21

Auto-fix by /housekeep Stage 4.

**Scope:** scripts/content-sync.mjs

**Description:** In pullRebaseWithRetry (lines 437-444), wrap inner git error with new Error('rebase-failed: ' + err.message) before rethrowing so classifyError's 'pull --rebase' substring lookup matches consistently.