### PR TITLE
feat(cli): add memory migrate-out/migrate-in for cross-machine portability

### DIFF
--- a/scripts/lib/migration-bundle.mjs
+++ b/scripts/lib/migration-bundle.mjs
@@ -1,0 +1,190 @@
+// Migration-bundle: shared helpers for `memory migrate-out` and
+// `memory migrate-in`.
+//
+// Responsibilities:
+//   - Host-id detection (used in default branch name like
+//     `migration/<host-id>-<YYYY-MM-DD>`).
+//   - Default branch name derivation.
+//   - Per-file commit-time lookup (`git log -1 --format=%ct <path>`).
+//   - Strategy resolution for migrate-in (prefer-local / prefer-remote /
+//     prefer-newer-commit) — including the untracked-card-as-Infinity rule
+//     that the plan calls out (AC 6b).
+//   - Tier-b enumeration (paths only — byte copy is the caller's job to
+//     preserve round-trip byte equality, AC-7).
+//
+// Deliberately minimal. No git side effects in this module — callers
+// (migrate-out.mjs / migrate-in.mjs) own the commit/push/checkout cycle
+// against a worktree of the content backup repo.
+
+import { existsSync, readdirSync, statSync, readFileSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+import { execFileSync } from "node:child_process";
+import { hostname } from "node:os";
+
+// --------------------------------------------------------------------
+// Host-id derivation.
+//
+// Default form: <os-family>-<sanitized-hostname>-<short-suffix>.
+//
+// The richest existing precedent (windows-ansonyoga-914b) uses the last 4
+// hex of `Win32_ComputerSystemProduct.UUID` for the suffix. That's
+// Windows-only and requires a privileged WMI call; here we fall back to
+// the first 4 hex of a sha256 over (os-family + hostname) so the slug is
+// host-stable without needing platform-specific probes.
+
+function osFamily() {
+  const p = process.platform;
+  if (p === "win32") return "windows";
+  if (p === "darwin") return "macos";
+  if (p === "linux") return "linux";
+  return p;
+}
+
+function sanitizeHostname(raw) {
+  return String(raw || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "")
+    .slice(0, 32) || "unknown";
+}
+
+function shortSuffix(seed) {
+  // Tiny non-cryptographic-quality hash is fine: this is for slug
+  // disambiguation only, never for security. Keep dependency-free.
+  let h = 2166136261;
+  for (let i = 0; i < seed.length; i++) {
+    h ^= seed.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return ((h >>> 0).toString(16) + "0000").slice(0, 4);
+}
+
+export function getHostId(opts = {}) {
+  const override = opts.override || process.env.MEMORY_HOST_ID;
+  if (override) return override;
+  const fam = osFamily();
+  const host = sanitizeHostname(opts.hostname || hostname());
+  const suffix = shortSuffix(`${fam}|${host}`);
+  return `${fam}-${host}-${suffix}`;
+}
+
+// --------------------------------------------------------------------
+// Branch name derivation.
+
+function todayUtcDate() {
+  const now = new Date();
+  // YYYY-MM-DD form, UTC.
+  return now.toISOString().slice(0, 10);
+}
+
+export function defaultMigrateBranch({ hostId, date } = {}) {
+  const id = hostId || getHostId();
+  const d = date || todayUtcDate();
+  return `migration/${id}-${d}`;
+}
+
+export function isMainBranch(name) {
+  return name === "main" || name === "master";
+}
+
+// --------------------------------------------------------------------
+// Tier-b enumeration.
+//
+// Returns relPath strings (forward-slash, tier-b-relative — same shape as
+// content-sync.mjs uses). The caller decides whether to filter by `pinned`
+// or include everything.
+
+export function listTierBCards(tierBRoot) {
+  const out = [];
+  const topicsDir = join(tierBRoot, "topics");
+  if (!existsSync(topicsDir)) return out;
+
+  function walk(dir) {
+    let entries;
+    try { entries = readdirSync(dir); } catch { return; }
+    for (const name of entries.sort()) {
+      const full = join(dir, name);
+      let st;
+      try { st = statSync(full); } catch { continue; }
+      if (st.isDirectory()) walk(full);
+      else if (st.isFile() && name.endsWith(".md")) {
+        const rel = relative(tierBRoot, full).split(sep).join("/");
+        out.push({ relPath: rel, absPath: full });
+      }
+    }
+  }
+  walk(topicsDir);
+  out.sort((a, b) => (a.relPath < b.relPath ? -1 : a.relPath > b.relPath ? 1 : 0));
+  return out;
+}
+
+// --------------------------------------------------------------------
+// Per-file commit time lookup.
+//
+// Returns a Number (Unix epoch seconds), or Infinity for "no commit" (the
+// path is untracked or has no commit history in the repo at `gitDir`).
+//
+// Why Infinity? AC 6b requires that a locally-untracked card always wins
+// over a remote-tracked one under prefer-newer-commit. parseInt("") is
+// NaN, and NaN comparisons silently return false — yielding wrong-side
+// wins. Treating empty as Infinity makes "untracked = freshest" explicit
+// and rules out the silent-overwrite path. See plan §Risks.
+
+export function getFileCommitTime(gitDir, relPath) {
+  try {
+    const out = execFileSync(
+      "git",
+      ["log", "-1", "--format=%ct", "--", relPath],
+      { cwd: gitDir, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+    ).trim();
+    if (!out) return Infinity;
+    const n = Number.parseInt(out, 10);
+    if (!Number.isFinite(n)) return Infinity;
+    return n;
+  } catch {
+    // Not a git dir, or git missing — treat as "no commit info" → Infinity
+    // (preserves the untracked-wins semantic).
+    return Infinity;
+  }
+}
+
+// --------------------------------------------------------------------
+// Strategy resolution for migrate-in conflict cases.
+//
+// localCommitTime / remoteCommitTime are Numbers (Infinity for untracked).
+// Returns "local" | "remote" — caller copies bytes accordingly.
+
+export function resolveStrategy(strategy, localCommitTime, remoteCommitTime) {
+  if (strategy === "prefer-local") return "local";
+  if (strategy === "prefer-remote") return "remote";
+  if (strategy === "prefer-newer-commit") {
+    // Both Infinity is degenerate (both untracked). Default: prefer-local
+    // — operator's freshest edit wins, matches the Phase-0-like semantic.
+    if (localCommitTime === Infinity && remoteCommitTime === Infinity) return "local";
+    // Standard case: bigger number = newer commit = wins.
+    return localCommitTime >= remoteCommitTime ? "local" : "remote";
+  }
+  throw new Error(`unknown strategy: ${strategy}`);
+}
+
+// --------------------------------------------------------------------
+// Pinned filter (parses front matter; doesn't re-emit).
+//
+// Returns true if `pinned: true` in the card's frontmatter. False on any
+// parse failure, missing field, or non-true value. Matches existing
+// content-filter behavior so default migrate-out filtering is consistent.
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n/;
+
+export function isPinned(absPath) {
+  let text;
+  try { text = readFileSync(absPath, "utf8"); } catch { return false; }
+  const m = FRONTMATTER_RE.exec(text);
+  if (!m) return false;
+  const lines = m[1].split(/\r?\n/);
+  for (const line of lines) {
+    const mm = /^pinned\s*:\s*(true|false)\s*$/i.exec(line);
+    if (mm) return mm[1].toLowerCase() === "true";
+  }
+  return false;
+}

--- a/scripts/lib/privacy-denylist.mjs
+++ b/scripts/lib/privacy-denylist.mjs
@@ -7,10 +7,9 @@
 //     (added 2026-04-17): never write the user's current employer's brand
 //     name (or common spellings / variants), or any award / specific metric
 //     that single-sources that employer.
-//   - C:/Users/ziyil/.claude/projects/.../memory/feedback_no_employer_mention.md
-//     — concrete substitutes / variants list ("UOB", "UOB Bank",
-//     "UOB Group", "UOB Mighty", and metric/award single-source
-//     identifiers).
+//   - per-project Claude memory feedback card "no_employer_mention" — the
+//     concrete substitutes / variants list (bare brand, brand+qualifier
+//     forms, single-source award metric).
 //   - Plan §"Privacy denylist seam" (2026-05-05) — case-insensitive,
 //     covers brand variants + common spellings; AC-9b mandates a separate
 //     test case for the variant surface.

--- a/scripts/lib/privacy-denylist.mjs
+++ b/scripts/lib/privacy-denylist.mjs
@@ -1,0 +1,101 @@
+// Privacy denylist: regex patterns for regulated tokens that must NEVER
+// appear in cards bound for a public-facing artefact (PR body, commit
+// message, branch on the content backup repo, etc.).
+//
+// Provenance:
+//   - parent-claude.md "## Privacy & Employer-Brand Hygiene" — hard rule
+//     (added 2026-04-17): never write the user's current employer's brand
+//     name (or common spellings / variants), or any award / specific metric
+//     that single-sources that employer.
+//   - C:/Users/ziyil/.claude/projects/.../memory/feedback_no_employer_mention.md
+//     — concrete substitutes / variants list ("UOB", "UOB Bank",
+//     "UOB Group", "UOB Mighty", and metric/award single-source
+//     identifiers).
+//   - Plan §"Privacy denylist seam" (2026-05-05) — case-insensitive,
+//     covers brand variants + common spellings; AC-9b mandates a separate
+//     test case for the variant surface.
+//
+// Per the plan: this module is the FIRST callable artefact derived from
+// the prose privacy spec. AC-9b consumers (migrate-out pre-flight; future
+// /ship adoption) should grep across all candidate text using these
+// patterns and refuse to ship on any match.
+//
+// Patterns are case-insensitive (the `i` flag) and use word-boundary or
+// equivalent gating to avoid false positives on substrings of unrelated
+// English words. Variant coverage:
+//   - Bare brand:         UOB
+//   - Brand + qualifier:  UOB Bank, UOB Group, UOB Mighty
+//   - Spaced variants:    "U O B", "U.O.B." (common typo / acronym
+//                         expansion forms)
+//   - Single-source award metric: "Best Foreign Bank in Malaysia
+//                                  (Asian Banker ...)"
+//
+// NOT included here (intentional out-of-scope):
+//   - Project-internal codenames that don't single-source the employer
+//     ("Customer Onboarding MY/SG", "Online Fraud Management", etc.) — the
+//     privacy spec explicitly carves these out.
+//   - Adjacent-employer names (e.g., "CIMB" — was an agency client via
+//     VMLY&R, not the user's employer; mention is permitted per the spec).
+//
+// Determinism: pure module. No I/O. Patterns are frozen at import time.
+
+// Each entry is { name, pattern } so callers can render a meaningful
+// reject reason (e.g., "PRIVACY-BLOCK pattern=brand-bare").
+export const DENYLIST_PATTERNS = Object.freeze([
+  // Bare brand token. \b on both sides so "uobiquitous" wouldn't match —
+  // (purely defensive; not a real word, but the gate matters for any
+  // future English text that happens to contain "uob" mid-word).
+  { name: "brand-bare", pattern: /\bUOB\b/i },
+  // Brand + qualifier — the explicit forms in the privacy spec.
+  { name: "brand-bank", pattern: /\bUOB\s+Bank\b/i },
+  { name: "brand-group", pattern: /\bUOB\s+Group\b/i },
+  { name: "brand-mighty", pattern: /\bUOB\s+Mighty\b/i },
+  // Geographic-qualifier forms ("UOB Malaysia", "UOB Singapore").
+  { name: "brand-region", pattern: /\bUOB\s+(Malaysia|Singapore|Indonesia|Thailand|Vietnam)\b/i },
+  // Spaced acronym variant ("U O B", "U.O.B."). \b around capital
+  // U because the acronym is capitalized in all observed forms; the `i`
+  // flag still allows lowercase matches.
+  { name: "brand-spaced", pattern: /\bU[\s.][\s.]?O[\s.][\s.]?B\b/i },
+  // Single-source award identifier from the privacy spec.
+  { name: "award-best-foreign-bank-my", pattern: /Best\s+Foreign\s+Bank\s+in\s+Malaysia/i },
+]);
+
+/**
+ * Scan a string for any denylist match. Returns the FIRST match found
+ * (deterministic: walks DENYLIST_PATTERNS in declaration order).
+ * Returns null if no match.
+ *
+ * @param {string} text
+ * @returns {{ name: string, match: string } | null}
+ */
+export function findFirstMatch(text) {
+  if (typeof text !== "string" || text.length === 0) return null;
+  for (const { name, pattern } of DENYLIST_PATTERNS) {
+    const m = pattern.exec(text);
+    if (m) return { name, match: m[0] };
+  }
+  return null;
+}
+
+/**
+ * Scan a string for ALL denylist matches. Useful for surfacing every
+ * regulated token in a single error message rather than fix-one-at-a-time.
+ *
+ * @param {string} text
+ * @returns {Array<{ name: string, match: string }>}
+ */
+export function findAllMatches(text) {
+  if (typeof text !== "string" || text.length === 0) return [];
+  const out = [];
+  for (const { name, pattern } of DENYLIST_PATTERNS) {
+    // Build a global variant for exhaustive scan; preserve case-insensitivity.
+    const flags = pattern.flags.includes("g") ? pattern.flags : pattern.flags + "g";
+    const gpattern = new RegExp(pattern.source, flags);
+    let m;
+    while ((m = gpattern.exec(text)) !== null) {
+      out.push({ name, match: m[0] });
+      if (m[0].length === 0) gpattern.lastIndex++; // safety against zero-width
+    }
+  }
+  return out;
+}

--- a/scripts/migrate-in.mjs
+++ b/scripts/migrate-in.mjs
@@ -1,0 +1,400 @@
+#!/usr/bin/env node
+// migrate-in: apply a transport branch from the agent-working-memory-content
+// backup repo into local tier-b, with a per-file merge strategy.
+//
+// Surface:
+//   memory migrate-in [--from-branch <name>]
+//                     [--strategy <prefer-local|prefer-remote|prefer-newer-commit>]
+//                     [--root PATH] [--clone PATH] [--remote URL]
+//                     [--dry-run] [--verbose]
+//
+// Default behavior:
+//   - From branch: most recent migration/* branch on the backup repo
+//     (sorted lexically descending — branch names embed YYYY-MM-DD so
+//     lex-desc = chronological-desc).
+//   - Strategy: prefer-newer-commit (uses `git log -1 --format=%ct <path>`
+//     on each side; locally-untracked cards win — see Plan AC 6b).
+//   - Round-trip: bytes are copied via copyFileSync, never re-parsed.
+//
+// Exit codes:
+//   0  — success
+//   1  — failure
+//   2  — bad usage / argument error
+
+import {
+  copyFileSync,
+  mkdirSync,
+  existsSync,
+  readdirSync,
+  statSync,
+} from "node:fs";
+import { join, dirname, sep, relative } from "node:path";
+import { homedir } from "node:os";
+import { execFileSync } from "node:child_process";
+
+import {
+  getFileCommitTime,
+  resolveStrategy,
+} from "./lib/migration-bundle.mjs";
+
+const DEFAULT_REMOTE = "https://github.com/ziyilam3999/agent-working-memory-content.git";
+const VALID_STRATEGIES = new Set(["prefer-local", "prefer-remote", "prefer-newer-commit"]);
+
+// --------------------------------------------------------------------
+// CLI parsing.
+
+function parseArgs(argv) {
+  const out = { dryRun: false, verbose: false, strategy: "prefer-newer-commit" };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--dry-run") out.dryRun = true;
+    else if (a === "--verbose") out.verbose = true;
+    else if (a === "--from-branch") out.fromBranch = argv[++i];
+    else if (a === "--strategy") out.strategy = argv[++i];
+    else if (a === "--root") out.root = argv[++i];
+    else if (a === "--clone") out.clone = argv[++i];
+    else if (a === "--remote") out.remote = argv[++i];
+    else if (a === "--help" || a === "-h") out.help = true;
+    else out.unknownArg = a;
+  }
+  return out;
+}
+
+function usage() {
+  return [
+    "usage: memory migrate-in [--from-branch NAME] [--strategy STRATEGY]",
+    "                         [--root PATH] [--clone PATH] [--remote URL]",
+    "                         [--dry-run] [--verbose]",
+    "",
+    "Apply a transport branch into local tier-b with per-file merge strategy.",
+    "",
+    "  --from-branch NAME      pull from NAME (default: most recent migration/*)",
+    "  --strategy STRATEGY     prefer-local | prefer-remote | prefer-newer-commit",
+    "                          (default: prefer-newer-commit; untracked-local wins)",
+    "  --root PATH             tier-b root (default: $WORKING_MEMORY_ROOT)",
+    "  --clone PATH            local clone path of the content backup repo",
+    "  --remote URL            override the content-repo remote URL",
+    "  --dry-run               print actions, no writes",
+    "  --verbose               extra debug output to stderr",
+    "",
+  ].join("\n");
+}
+
+// --------------------------------------------------------------------
+// Path resolution.
+
+function resolveRoot(arg) {
+  if (arg) return arg;
+  if (process.env.WORKING_MEMORY_ROOT) return process.env.WORKING_MEMORY_ROOT;
+  return join(homedir(), ".claude", "agent-working-memory");
+}
+
+function resolveClone(arg) {
+  if (arg) return arg;
+  if (process.env.MIGRATE_REPO_CLONE) return process.env.MIGRATE_REPO_CLONE;
+  if (process.env.CONTENT_REPO_CLONE) return process.env.CONTENT_REPO_CLONE;
+  return join(homedir(), ".claude", "agent-working-memory", "migrate-repo-clone");
+}
+
+function resolveRemote(arg) {
+  if (arg) return arg;
+  if (process.env.MIGRATE_REPO_REMOTE) return process.env.MIGRATE_REPO_REMOTE;
+  if (process.env.CONTENT_REPO_REMOTE) return process.env.CONTENT_REPO_REMOTE;
+  return DEFAULT_REMOTE;
+}
+
+// --------------------------------------------------------------------
+// Git helpers.
+
+function git(cwd, args, opts = {}) {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: opts.stdio || ["ignore", "pipe", "pipe"],
+    env: { ...process.env, ...(opts.env || {}) },
+  });
+}
+
+function ensureClone(cloneRoot, remoteUrl) {
+  if (existsSync(join(cloneRoot, ".git"))) return;
+  mkdirSync(dirname(cloneRoot), { recursive: true });
+  // Force core.autocrlf=false on the clone so byte-level round-trip
+  // (AC-7) holds on Windows hosts where the global git config has
+  // autocrlf=true. Migrate-in only ever copyFileSync's bytes from the
+  // checked-out worktree into the local tier-b — it never re-parses or
+  // canonicalizes — so disabling autocrlf is the safe default.
+  execFileSync("git", ["-c", "core.autocrlf=false", "clone", remoteUrl, cloneRoot], {
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf8",
+  });
+  try {
+    execFileSync("git", ["config", "core.autocrlf", "false"], {
+      cwd: cloneRoot, stdio: "ignore",
+    });
+    execFileSync("git", ["config", "core.eol", "lf"], {
+      cwd: cloneRoot, stdio: "ignore",
+    });
+    // Re-checkout to apply the new line-ending policy to the working tree.
+    execFileSync("git", ["checkout", "--", "."], { cwd: cloneRoot, stdio: "ignore" });
+  } catch { /* tolerate — best-effort */ }
+}
+
+function configureAuthor(cloneRoot) {
+  if (process.env.MIGRATE_AUTHOR_NAME) {
+    git(cloneRoot, ["config", "user.name", process.env.MIGRATE_AUTHOR_NAME]);
+  }
+  if (process.env.MIGRATE_AUTHOR_EMAIL) {
+    git(cloneRoot, ["config", "user.email", process.env.MIGRATE_AUTHOR_EMAIL]);
+  }
+}
+
+function listRemoteMigrationBranches(cloneRoot) {
+  try {
+    const out = git(cloneRoot, ["branch", "-r", "--list", "origin/migration/*"]);
+    return out.split(/\r?\n/)
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map((s) => s.replace(/^origin\//, ""))
+      .sort()
+      .reverse(); // lex-desc = date-desc since the slug embeds YYYY-MM-DD
+  } catch {
+    return [];
+  }
+}
+
+function checkoutBranch(cloneRoot, branch) {
+  // Fetch then checkout to a detached state — we don't need to track or
+  // commit; we only read.
+  git(cloneRoot, ["fetch", "origin", branch]);
+  git(cloneRoot, ["checkout", "-B", branch, `origin/${branch}`]);
+}
+
+// --------------------------------------------------------------------
+// Tier-b enumeration in either local root or clone.
+
+function listMdFilesUnder(root) {
+  const out = []; // { relPath (forward-slash, root-relative), absPath }
+  if (!existsSync(root)) return out;
+  function walk(dir) {
+    let entries;
+    try { entries = readdirSync(dir); } catch { return; }
+    for (const name of entries.sort()) {
+      const full = join(dir, name);
+      let st;
+      try { st = statSync(full); } catch { continue; }
+      if (st.isDirectory()) walk(full);
+      else if (st.isFile() && name.endsWith(".md")) {
+        const rel = relative(root, full).split(sep).join("/");
+        out.push({ relPath: rel, absPath: full });
+      }
+    }
+  }
+  walk(root);
+  return out;
+}
+
+// --------------------------------------------------------------------
+// Decision: per-relPath, where does the winning bytes come from?
+
+export function planMerge({ localTierBRoot, remoteTierBRoot, localGitDir, remoteGitDir, strategy }) {
+  // Forward-slash relPath under tier-b/ (matches content-sync convention).
+  const localFiles = new Map(); // relPath -> absPath
+  for (const f of listMdFilesUnder(join(localTierBRoot, "topics"))) {
+    localFiles.set(`topics/${f.relPath}`, join(localTierBRoot, "topics", f.relPath.split("/").join(sep)));
+  }
+  const remoteFiles = new Map();
+  for (const f of listMdFilesUnder(join(remoteTierBRoot, "topics"))) {
+    remoteFiles.set(`topics/${f.relPath}`, join(remoteTierBRoot, "topics", f.relPath.split("/").join(sep)));
+  }
+
+  const allRel = new Set([...localFiles.keys(), ...remoteFiles.keys()]);
+  const decisions = []; // { relPath, action: "copy-from-remote" | "keep-local" | "add-from-remote", reason }
+
+  for (const rel of [...allRel].sort()) {
+    const onLocal = localFiles.has(rel);
+    const onRemote = remoteFiles.has(rel);
+    if (onRemote && !onLocal) {
+      decisions.push({ relPath: rel, action: "add-from-remote", reason: "local-missing" });
+      continue;
+    }
+    if (onLocal && !onRemote) {
+      // Strategy doesn't enter; remote has nothing to say.
+      decisions.push({ relPath: rel, action: "keep-local", reason: "remote-missing" });
+      continue;
+    }
+    // Both present — strategy resolves.
+    const localCt = getFileCommitTime(localGitDir, join("tier-b", rel).split(sep).join("/"));
+    const remoteCt = getFileCommitTime(remoteGitDir, join("tier-b", rel).split(sep).join("/"));
+    const winner = resolveStrategy(strategy, localCt, remoteCt);
+    if (winner === "remote") {
+      decisions.push({
+        relPath: rel,
+        action: "copy-from-remote",
+        reason: `strategy=${strategy} local-ct=${localCt} remote-ct=${remoteCt}`,
+      });
+    } else {
+      decisions.push({
+        relPath: rel,
+        action: "keep-local",
+        reason: `strategy=${strategy} local-ct=${localCt} remote-ct=${remoteCt}`,
+      });
+    }
+  }
+
+  return { decisions, localFiles, remoteFiles };
+}
+
+// --------------------------------------------------------------------
+// Main entry (programmatic).
+
+export async function runMigrateIn(opts = {}) {
+  const tierBRoot = join(resolveRoot(opts.root), "tier-b");
+  const cloneRoot = resolveClone(opts.clone);
+  const remoteUrl = resolveRemote(opts.remote);
+  const strategy = opts.strategy || "prefer-newer-commit";
+  const dryRun = !!opts.dryRun;
+  const verbose = !!opts.verbose;
+
+  const log = (msg) => { if (verbose) process.stderr.write(`migrate-in: ${msg}\n`); };
+
+  if (!VALID_STRATEGIES.has(strategy)) {
+    return { exitCode: 2, error: `unknown strategy: ${strategy}`, errClass: "bad-arg" };
+  }
+
+  // 1. Set up the clone.
+  try {
+    ensureClone(cloneRoot, remoteUrl);
+    log(`clone at ${cloneRoot}`);
+    configureAuthor(cloneRoot);
+  } catch (err) {
+    return { exitCode: 1, error: `clone failed: ${err.message}`, errClass: "git" };
+  }
+
+  // 2. Pick the from-branch.
+  let fromBranch = opts.fromBranch;
+  if (!fromBranch) {
+    try { git(cloneRoot, ["fetch", "origin"]); } catch { /* tolerate, listRemoteMigrationBranches is best-effort */ }
+    const candidates = listRemoteMigrationBranches(cloneRoot);
+    if (candidates.length === 0) {
+      return {
+        exitCode: 1,
+        error: "no migration/* branches found on remote; pass --from-branch explicitly",
+        errClass: "no-migration-branch",
+      };
+    }
+    fromBranch = candidates[0];
+    log(`auto-selected from-branch: ${fromBranch}`);
+  }
+
+  // 3. Check out the from-branch.
+  try {
+    checkoutBranch(cloneRoot, fromBranch);
+    log(`checked out ${fromBranch}`);
+  } catch (err) {
+    return { exitCode: 1, error: `checkout ${fromBranch} failed: ${err.message}`, errClass: "git" };
+  }
+
+  // 4. Compute the merge plan.
+  // Note: getFileCommitTime treats no-commit-found as Infinity; AC 6b
+  // requires this to be the local-untracked semantic ("untracked = newest").
+  // The local tier-b root may not be a git repo (the user's home tier-b
+  // tree usually isn't). In that case the fallback cleanly returns
+  // Infinity so untracked still wins.
+  const localGitDir = findLocalGitRoot(tierBRoot) || tierBRoot;
+  const remoteGitDir = cloneRoot;
+  const remoteTierBRoot = join(cloneRoot, "tier-b");
+
+  const { decisions } = planMerge({
+    localTierBRoot: tierBRoot,
+    remoteTierBRoot,
+    localGitDir,
+    remoteGitDir,
+    strategy,
+  });
+
+  if (dryRun) {
+    const lines = decisions.map((d) => `${d.action} ${d.relPath} (${d.reason})`);
+    return {
+      exitCode: 0,
+      dryRun: true,
+      output: `from-branch: ${fromBranch}\nstrategy: ${strategy}\n` + lines.join("\n") + (lines.length ? "\n" : ""),
+      decisions,
+      fromBranch,
+    };
+  }
+
+  // 5. Execute the plan.
+  let written = 0;
+  for (const d of decisions) {
+    if (d.action === "keep-local") continue;
+    const dest = join(tierBRoot, d.relPath.split("/").join(sep));
+    const srcRelOnRemote = d.relPath.split("/").join(sep);
+    const src = join(remoteTierBRoot, srcRelOnRemote);
+    mkdirSync(dirname(dest), { recursive: true });
+    copyFileSync(src, dest);
+    written += 1;
+  }
+
+  return { exitCode: 0, fromBranch, strategy, decisions, written };
+}
+
+function findLocalGitRoot(startDir) {
+  // Walk upward from startDir; if any ancestor has .git, return it. This
+  // lets the test harness point migrate-in at a non-git tier-b root and
+  // still get the "no commit info → Infinity" fallback (the test relies on
+  // it for the untracked-card AC 6b case).
+  let cur = startDir;
+  while (cur) {
+    if (existsSync(join(cur, ".git"))) return cur;
+    const parent = dirname(cur);
+    if (parent === cur) return null;
+    cur = parent;
+  }
+  return null;
+}
+
+// --------------------------------------------------------------------
+// CLI entry.
+
+export async function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    process.stdout.write(usage());
+    return 0;
+  }
+  if (args.unknownArg) {
+    process.stderr.write(`migrate-in: unknown arg: ${args.unknownArg}\n${usage()}`);
+    return 2;
+  }
+  const r = await runMigrateIn({
+    fromBranch: args.fromBranch,
+    strategy: args.strategy,
+    root: args.root,
+    clone: args.clone,
+    remote: args.remote,
+    dryRun: args.dryRun,
+    verbose: args.verbose,
+  });
+  if (r.dryRun) {
+    process.stdout.write(r.output);
+    return r.exitCode;
+  }
+  if (r.exitCode === 0) {
+    process.stdout.write(`migrate-in: from=${r.fromBranch} strategy=${r.strategy} wrote=${r.written}\n`);
+  } else {
+    process.stderr.write(`migrate-in: FAILED class=${r.errClass} ${r.error}\n`);
+  }
+  return r.exitCode;
+}
+
+const invokedAsCli =
+  import.meta.url === `file://${process.argv[1]}` ||
+  process.argv[1]?.endsWith("migrate-in.mjs");
+if (invokedAsCli) {
+  main()
+    .then((c) => process.exit(c || 0))
+    .catch((e) => {
+      process.stderr.write(`migrate-in: unexpected error: ${e.message}\n`);
+      process.exit(1);
+    });
+}

--- a/scripts/migrate-out.mjs
+++ b/scripts/migrate-out.mjs
@@ -1,0 +1,375 @@
+#!/usr/bin/env node
+// migrate-out: bundle local tier-b cards into a transport branch on the
+// agent-working-memory-content backup repo.
+//
+// Mental model: a migration is an explicit cross-machine handoff snapshot,
+// not a daily push. Migration branches live on the backup repo
+// (`migration/<host-id>-<YYYY-MM-DD>` by default) — distinct from `main`
+// which the daily content-sync cron owns.
+//
+// Surface:
+//   memory migrate-out [--target-branch <name>] [--include-non-pinned]
+//                      [--root PATH] [--clone PATH] [--dry-run] [--verbose]
+//
+// Default behavior:
+//   - Target branch: migration/<host-id>-<YYYY-MM-DD> (auto-derived).
+//   - Filter: only `pinned: true` cards (matches the daily cron's filter).
+//     `--include-non-pinned` widens to every tier-b card.
+//   - NEVER writes to `main` (or `master`). Refusal-class error if
+//     --target-branch resolves to a protected name.
+//   - Pre-flight: scan all candidate cards for regulated-token matches via
+//     scripts/lib/privacy-denylist.mjs. If any match, exit non-zero with
+//     `PRIVACY-BLOCK` on stderr — no commit, no push.
+//
+// Round-trip guarantee: cards are copied byte-for-byte (no YAML re-parse,
+// no canonicalization), so AC-7 holds.
+//
+// Exit codes:
+//   0  — success (push, dry-run, or no-op)
+//   1  — failure (privacy block, git error, etc.)
+//   2  — bad usage / argument error
+
+import {
+  readFileSync,
+  copyFileSync,
+  mkdirSync,
+  existsSync,
+  rmSync,
+} from "node:fs";
+import { join, dirname, sep } from "node:path";
+import { homedir } from "node:os";
+import { execFileSync } from "node:child_process";
+
+import {
+  getHostId,
+  defaultMigrateBranch,
+  isMainBranch,
+  listTierBCards,
+  isPinned,
+} from "./lib/migration-bundle.mjs";
+import { findFirstMatch } from "./lib/privacy-denylist.mjs";
+
+const DEFAULT_REMOTE = "https://github.com/ziyilam3999/agent-working-memory-content.git";
+
+// --------------------------------------------------------------------
+// CLI parsing.
+
+function parseArgs(argv) {
+  const out = { dryRun: false, verbose: false, includeNonPinned: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--dry-run") out.dryRun = true;
+    else if (a === "--verbose") out.verbose = true;
+    else if (a === "--include-non-pinned") out.includeNonPinned = true;
+    else if (a === "--target-branch") out.targetBranch = argv[++i];
+    else if (a === "--root") out.root = argv[++i];
+    else if (a === "--clone") out.clone = argv[++i];
+    else if (a === "--remote") out.remote = argv[++i];
+    else if (a === "--help" || a === "-h") out.help = true;
+    else out.unknownArg = a;
+  }
+  return out;
+}
+
+function usage() {
+  return [
+    "usage: memory migrate-out [--target-branch NAME] [--include-non-pinned]",
+    "                          [--root PATH] [--clone PATH] [--remote URL]",
+    "                          [--dry-run] [--verbose]",
+    "",
+    "Bundle local tier-b cards into a migration branch on the content backup repo.",
+    "",
+    "  --target-branch NAME    push to NAME instead of migration/<host-id>-<date>",
+    "                          (NAME must NOT be 'main' or 'master')",
+    "  --include-non-pinned    include unpinned cards too (default: pinned only)",
+    "  --root PATH             tier-b root (default: $WORKING_MEMORY_ROOT)",
+    "  --clone PATH            local clone path of the content backup repo",
+    "  --remote URL            override the content-repo remote URL",
+    "  --dry-run               print actions, no writes, no commits",
+    "  --verbose               extra debug output to stderr",
+    "",
+  ].join("\n");
+}
+
+// --------------------------------------------------------------------
+// Path resolution.
+
+function resolveRoot(arg) {
+  if (arg) return arg;
+  if (process.env.WORKING_MEMORY_ROOT) return process.env.WORKING_MEMORY_ROOT;
+  return join(homedir(), ".claude", "agent-working-memory");
+}
+
+function resolveClone(arg) {
+  if (arg) return arg;
+  if (process.env.MIGRATE_REPO_CLONE) return process.env.MIGRATE_REPO_CLONE;
+  if (process.env.CONTENT_REPO_CLONE) return process.env.CONTENT_REPO_CLONE;
+  // Migrate uses its own clone path so it doesn't fight with content-sync's
+  // clone. Each command can keep its own checkout state.
+  return join(homedir(), ".claude", "agent-working-memory", "migrate-repo-clone");
+}
+
+function resolveRemote(arg) {
+  if (arg) return arg;
+  if (process.env.MIGRATE_REPO_REMOTE) return process.env.MIGRATE_REPO_REMOTE;
+  if (process.env.CONTENT_REPO_REMOTE) return process.env.CONTENT_REPO_REMOTE;
+  return DEFAULT_REMOTE;
+}
+
+// --------------------------------------------------------------------
+// Git helpers.
+
+function git(cwd, args, opts = {}) {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: opts.stdio || ["ignore", "pipe", "pipe"],
+    env: { ...process.env, ...(opts.env || {}) },
+  });
+}
+
+function ensureClone(cloneRoot, remoteUrl) {
+  if (existsSync(join(cloneRoot, ".git"))) return;
+  mkdirSync(dirname(cloneRoot), { recursive: true });
+  // Clone without specifying a branch — we'll create or check out the
+  // target branch ourselves below. This avoids the "branch not found"
+  // failure when the migration branch doesn't exist yet on the remote.
+  // Force core.autocrlf=false on the clone so byte-level round-trip
+  // (AC-7) holds on Windows hosts where the global git config has
+  // autocrlf=true. We never edit .md text content here — bytes flow
+  // through unmodified — so disabling autocrlf is the safe default.
+  execFileSync("git", ["-c", "core.autocrlf=false", "clone", remoteUrl, cloneRoot], {
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf8",
+  });
+  try {
+    execFileSync("git", ["config", "core.autocrlf", "false"], {
+      cwd: cloneRoot, stdio: "ignore",
+    });
+    execFileSync("git", ["config", "core.eol", "lf"], {
+      cwd: cloneRoot, stdio: "ignore",
+    });
+  } catch { /* tolerate — best-effort */ }
+}
+
+function configureAuthor(cloneRoot) {
+  if (process.env.MIGRATE_AUTHOR_NAME) {
+    git(cloneRoot, ["config", "user.name", process.env.MIGRATE_AUTHOR_NAME]);
+  }
+  if (process.env.MIGRATE_AUTHOR_EMAIL) {
+    git(cloneRoot, ["config", "user.email", process.env.MIGRATE_AUTHOR_EMAIL]);
+  }
+}
+
+function checkoutTargetBranch(cloneRoot, branch) {
+  // Try to fetch the branch from origin if it exists already.
+  try {
+    git(cloneRoot, ["fetch", "origin", branch]);
+    git(cloneRoot, ["checkout", "-B", branch, `origin/${branch}`]);
+    return;
+  } catch {
+    // Not yet on remote — create from current HEAD (default branch HEAD
+    // after clone). This is the first-push case.
+  }
+  try {
+    git(cloneRoot, ["checkout", "-B", branch]);
+  } catch (err) {
+    throw new Error(`failed to create branch ${branch}: ${err.message}`);
+  }
+}
+
+// --------------------------------------------------------------------
+// Privacy pre-flight: scan every candidate card for regulated tokens.
+
+export function privacyPreflight(cards) {
+  const violations = [];
+  for (const card of cards) {
+    let text;
+    try { text = readFileSync(card.absPath, "utf8"); } catch { continue; }
+    const hit = findFirstMatch(text);
+    if (hit) violations.push({ relPath: card.relPath, ...hit });
+  }
+  return violations;
+}
+
+// --------------------------------------------------------------------
+// Main entry (programmatic).
+
+export async function runMigrateOut(opts = {}) {
+  const tierBRoot = join(resolveRoot(opts.root), "tier-b");
+  const cloneRoot = resolveClone(opts.clone);
+  const remoteUrl = resolveRemote(opts.remote);
+  const branch = opts.targetBranch || defaultMigrateBranch();
+  const includeNonPinned = !!opts.includeNonPinned;
+  const dryRun = !!opts.dryRun;
+  const verbose = !!opts.verbose;
+  const skipPush = process.env.MIGRATE_SKIP_PUSH === "1" || opts.skipPush === true;
+
+  const log = (msg) => { if (verbose) process.stderr.write(`migrate-out: ${msg}\n`); };
+
+  if (isMainBranch(branch)) {
+    return {
+      exitCode: 1,
+      error: `refusing to push to protected branch '${branch}'. Use a migration/* branch instead.`,
+      errClass: "protected-branch",
+    };
+  }
+
+  // 1. Enumerate tier-b cards on disk.
+  const allCards = listTierBCards(tierBRoot);
+  const cards = includeNonPinned
+    ? allCards
+    : allCards.filter((c) => isPinned(c.absPath));
+
+  log(`enumerated ${allCards.length} cards (${cards.length} after filter, includeNonPinned=${includeNonPinned})`);
+
+  // 2. Privacy pre-flight. ALWAYS runs, even in dry-run, so the operator
+  //    sees the block immediately rather than discovering it on push.
+  const violations = privacyPreflight(cards);
+  if (violations.length > 0) {
+    const lines = violations.slice(0, 10).map((v) => `  ${v.relPath}: pattern=${v.name} match=${JSON.stringify(v.match)}`);
+    const more = violations.length > 10 ? `  ... and ${violations.length - 10} more\n` : "";
+    process.stderr.write(
+      `PRIVACY-BLOCK migrate-out aborted — ${violations.length} card(s) contain regulated tokens:\n` +
+      lines.join("\n") + (lines.length ? "\n" : "") + more,
+    );
+    return {
+      exitCode: 1,
+      error: `PRIVACY-BLOCK ${violations.length} regulated-token match(es)`,
+      errClass: "privacy-block",
+      violations,
+    };
+  }
+
+  if (dryRun) {
+    const out = cards.map((c) => `BUNDLE ${c.relPath}`).join("\n") + (cards.length ? "\n" : "");
+    return {
+      exitCode: 0,
+      branch,
+      dryRun: true,
+      output: `branch: ${branch}\n${out}`,
+      bundled: cards.length,
+    };
+  }
+
+  // 3. Set up the clone + checkout the target branch.
+  try {
+    ensureClone(cloneRoot, remoteUrl);
+    log(`clone at ${cloneRoot}`);
+    configureAuthor(cloneRoot);
+    checkoutTargetBranch(cloneRoot, branch);
+    log(`checked out branch ${branch}`);
+  } catch (err) {
+    return { exitCode: 1, error: `clone/checkout failed: ${err.message}`, errClass: "git" };
+  }
+
+  // 4. Copy bytes into the worktree's tier-b/ tree.
+  // listTierBCards returns relPaths like "topics/<topic>/<id>.md" (relative
+  // to the local tier-b root). The backup repo mirrors this under tier-b/,
+  // so the destination is <clone>/tier-b/<relPath>.
+  const touched = [];
+  for (const c of cards) {
+    const destRel = join("tier-b", c.relPath);
+    const dest = join(cloneRoot, destRel);
+    mkdirSync(dirname(dest), { recursive: true });
+    copyFileSync(c.absPath, dest);
+    touched.push(destRel.split(sep).join("/"));
+  }
+
+  // 5. Stage explicitly (one path at a time — no `git add .`).
+  for (const path of touched) {
+    try { git(cloneRoot, ["add", "--", path]); }
+    catch (err) {
+      return { exitCode: 1, error: `git add ${path} failed: ${err.message}`, errClass: "git" };
+    }
+  }
+
+  // 6. Detect whether anything is actually staged.
+  let hasStaged = true;
+  try {
+    git(cloneRoot, ["diff", "--cached", "--quiet"]);
+    hasStaged = false;
+  } catch {
+    hasStaged = true;
+  }
+  if (!hasStaged) {
+    log("no delta — nothing to commit");
+    return { exitCode: 0, branch, bundled: touched.length, committed: false, pushed: false };
+  }
+
+  // 7. Commit + push.
+  const subject = `chore(migrate-out): ${cards.length} card(s) from ${getHostId()}`;
+  try {
+    git(cloneRoot, ["commit", "-m", subject]);
+    log(`committed: ${subject}`);
+  } catch (err) {
+    return { exitCode: 1, error: `git commit failed: ${err.message}`, errClass: "git" };
+  }
+
+  let pushed = false;
+  if (!skipPush) {
+    try {
+      git(cloneRoot, ["push", "origin", branch]);
+      pushed = true;
+      log(`pushed origin/${branch}`);
+    } catch (err) {
+      return { exitCode: 1, error: `git push failed: ${err.message}`, errClass: "push-failed" };
+    }
+  }
+
+  return { exitCode: 0, branch, bundled: touched.length, committed: true, pushed, subject };
+}
+
+// --------------------------------------------------------------------
+// CLI entry.
+
+export async function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    process.stdout.write(usage());
+    return 0;
+  }
+  if (args.unknownArg) {
+    process.stderr.write(`migrate-out: unknown arg: ${args.unknownArg}\n${usage()}`);
+    return 2;
+  }
+  const r = await runMigrateOut({
+    targetBranch: args.targetBranch,
+    includeNonPinned: args.includeNonPinned,
+    root: args.root,
+    clone: args.clone,
+    remote: args.remote,
+    dryRun: args.dryRun,
+    verbose: args.verbose,
+  });
+  if (r.dryRun) {
+    process.stdout.write(r.output);
+    return r.exitCode;
+  }
+  if (r.exitCode === 0) {
+    if (r.committed) {
+      process.stdout.write(`migrate-out: ${r.subject} → ${r.branch} (pushed=${r.pushed})\n`);
+    } else {
+      process.stdout.write(`migrate-out: no delta on ${r.branch}\n`);
+    }
+  } else {
+    if (r.errClass !== "privacy-block") {
+      // privacy-block already wrote PRIVACY-BLOCK on stderr in
+      // privacyPreflight; don't double-report.
+      process.stderr.write(`migrate-out: FAILED class=${r.errClass} ${r.error}\n`);
+    }
+  }
+  return r.exitCode;
+}
+
+const invokedAsCli =
+  import.meta.url === `file://${process.argv[1]}` ||
+  process.argv[1]?.endsWith("migrate-out.mjs");
+if (invokedAsCli) {
+  main()
+    .then((c) => process.exit(c || 0))
+    .catch((e) => {
+      process.stderr.write(`migrate-out: unexpected error: ${e.message}\n`);
+      process.exit(1);
+    });
+}

--- a/src/memory-cli.mjs
+++ b/src/memory-cli.mjs
@@ -6,6 +6,8 @@ import { refresh, resolveRoot } from "./refresh.mjs";
 import { writeCard } from "./write-card.mjs";
 import { scanTree } from "./hygiene.mjs";
 import { loadCards, compact } from "./compact.mjs";
+import { main as migrateOutMain } from "../scripts/migrate-out.mjs";
+import { main as migrateInMain } from "../scripts/migrate-in.mjs";
 import { join } from "node:path";
 
 const [, , sub, ...rest] = process.argv;
@@ -19,6 +21,17 @@ subcommands:
   write --topic T --id I --title S [--pinned] [--root R]
                                     create a new tier-b card
   hygiene [ROOT]                    scan ROOT for hygiene violations (default .)
+  migrate-out [--target-branch N] [--include-non-pinned] [--dry-run]
+                                    bundle local tier-b into a transport branch
+                                    on the content backup repo (default branch:
+                                    migration/<host-id>-<YYYY-MM-DD>; default
+                                    filter: pinned only). Refuses to write to
+                                    'main'/'master'. Privacy denylist pre-flight.
+  migrate-in [--from-branch N] [--strategy S] [--dry-run]
+                                    apply a transport branch into local tier-b.
+                                    strategy ∈ {prefer-local, prefer-remote,
+                                    prefer-newer-commit}; default
+                                    prefer-newer-commit (untracked-local wins).
   help                              show this message
 `);
 }
@@ -36,7 +49,7 @@ function parseKV(argv) {
   return out;
 }
 
-try {
+async function dispatch() {
   switch (sub) {
     case "refresh": {
       const kv = parseKV(rest);
@@ -73,6 +86,16 @@ try {
       for (const x of v) process.stderr.write(`${x.file}:${x.line} [${x.pattern}]\n`);
       process.exit(1);
     }
+    case "migrate-out": {
+      // Delegate parsing to the migrate-out module's own CLI parser so the
+      // top-level dispatcher stays thin.
+      const code = await migrateOutMain(rest);
+      process.exit(code || 0);
+    }
+    case "migrate-in": {
+      const code = await migrateInMain(rest);
+      process.exit(code || 0);
+    }
     case undefined:
     case "help":
     case "-h":
@@ -83,7 +106,9 @@ try {
       help();
       process.exit(2);
   }
-} catch (e) {
+}
+
+dispatch().catch((e) => {
   process.stderr.write(`error: ${e.message}\n`);
   process.exit(1);
-}
+});

--- a/tests/migrate.test.mjs
+++ b/tests/migrate.test.mjs
@@ -1,0 +1,702 @@
+// migrate.test.mjs
+//
+// Covers the AC-4 / AC-5 / AC-6 / AC-6b / AC-7 / AC-9 / AC-9b cases for the
+// new `memory migrate-out` and `memory migrate-in` subcommands.
+//
+// All tests use isolated tmp dirs, a local bare repo as the "remote" backup
+// repo (no network), and the env-var seams documented in
+// scripts/migrate-out.mjs + scripts/migrate-in.mjs. None touch the user's
+// real working tree.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+} from "node:fs";
+import * as importedFs from "node:fs";
+import { tmpdir } from "node:os";
+import { join, sep } from "node:path";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+
+import { runMigrateOut } from "../scripts/migrate-out.mjs";
+import { runMigrateIn } from "../scripts/migrate-in.mjs";
+import {
+  getHostId,
+  defaultMigrateBranch,
+  isMainBranch,
+  resolveStrategy,
+  isPinned,
+} from "../scripts/lib/migration-bundle.mjs";
+import { findFirstMatch } from "../scripts/lib/privacy-denylist.mjs";
+
+// --------------------------------------------------------------------
+// Helpers.
+
+function makeCard({ id, topic, title, pinned, created = "2026-04-25", body = null }) {
+  const lines = [
+    "---",
+    `id: ${id}`,
+    `topic: ${topic}`,
+    `title: ${title}`,
+    `created: ${created}`,
+    `pinned: ${pinned}`,
+    "tags: []",
+    "---",
+    "",
+    "## Decision",
+    body || `Body for ${id}.`,
+    "",
+  ];
+  return lines.join("\n");
+}
+
+function seedTierB(tierBRoot, cards) {
+  for (const c of cards) {
+    const dir = join(tierBRoot, "topics", c.topic);
+    mkdirSync(dir, { recursive: true });
+    const path = join(dir, `${c.id}.md`);
+    writeFileSync(path, c.text || makeCard(c), "utf8");
+  }
+}
+
+// Make a tmp dir, then init a bare-equivalent local "origin" git repo. The
+// seed commit on `main` is empty-ish (just a README) so any tier-b/ tree
+// shows up as fresh content. Returns { remoteUrl, tmpRoot }.
+function makeLocalRemote(tmpRoot) {
+  const bare = join(tmpRoot, "remote.git");
+  mkdirSync(bare, { recursive: true });
+  execFileSync("git", ["init", "--bare", "--initial-branch=main", bare], { stdio: "ignore" });
+
+  const seed = join(tmpRoot, "seed");
+  mkdirSync(seed, { recursive: true });
+  execFileSync("git", ["init", "--initial-branch=main", seed], { stdio: "ignore" });
+  execFileSync("git", ["config", "user.email", "test@test"], { cwd: seed, stdio: "ignore" });
+  execFileSync("git", ["config", "user.name", "Test"], { cwd: seed, stdio: "ignore" });
+  writeFileSync(join(seed, "README.md"), "# content\n", "utf8");
+  execFileSync("git", ["add", "README.md"], { cwd: seed, stdio: "ignore" });
+  execFileSync("git", ["commit", "-m", "initial"], { cwd: seed, stdio: "ignore" });
+  execFileSync("git", ["remote", "add", "origin", bare], { cwd: seed, stdio: "ignore" });
+  execFileSync("git", ["push", "origin", "main"], { cwd: seed, stdio: "ignore" });
+
+  return { remoteUrl: bare };
+}
+
+// Tree-hash helper (hashTierBTreeOf) is defined at the bottom; it's the
+// round-trip equality oracle for AC-7.
+
+// Save/restore env helpers.
+function saveEnv(keys) {
+  const out = {};
+  for (const k of keys) out[k] = process.env[k];
+  return out;
+}
+function applyEnv(env) {
+  for (const [k, v] of Object.entries(env)) {
+    if (v === undefined || v === null) delete process.env[k];
+    else process.env[k] = v;
+  }
+}
+function restoreEnv(saved) {
+  for (const [k, v] of Object.entries(saved)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+}
+
+// Init a git repo at tier-b root and commit everything currently there. Used
+// by tests that need a local commit-time signal (AC-6 both-tracked case).
+function gitInitAndCommit(rootDir, message = "seed") {
+  execFileSync("git", ["init", "--initial-branch=main", rootDir], { stdio: "ignore" });
+  execFileSync("git", ["config", "user.email", "test@test"], { cwd: rootDir, stdio: "ignore" });
+  execFileSync("git", ["config", "user.name", "Test"], { cwd: rootDir, stdio: "ignore" });
+  execFileSync("git", ["add", "."], { cwd: rootDir, stdio: "ignore" });
+  execFileSync("git", ["commit", "-m", message], { cwd: rootDir, stdio: "ignore" });
+}
+
+// --------------------------------------------------------------------
+// 0. Unit tests for migration-bundle helpers.
+
+test("migration-bundle: defaultMigrateBranch is non-main and date-stamped", () => {
+  const branch = defaultMigrateBranch();
+  assert.ok(!isMainBranch(branch), `default branch must not be main, got: ${branch}`);
+  assert.match(branch, /^migration\/.+-\d{4}-\d{2}-\d{2}$/);
+});
+
+test("migration-bundle: getHostId is stable across calls and host-shaped", () => {
+  const a = getHostId();
+  const b = getHostId();
+  assert.equal(a, b);
+  assert.match(a, /^[a-z]+-[a-z0-9-]+-[0-9a-f]{4}$/);
+});
+
+test("migration-bundle: isPinned reads pinned: true correctly", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "awm-mig-pin-"));
+  const path = join(tmp, "card.md");
+  writeFileSync(path, makeCard({ id: "p", topic: "demo", title: "x", pinned: true }), "utf8");
+  assert.equal(isPinned(path), true);
+
+  const path2 = join(tmp, "card2.md");
+  writeFileSync(path2, makeCard({ id: "p2", topic: "demo", title: "x", pinned: false }), "utf8");
+  assert.equal(isPinned(path2), false);
+});
+
+test("migration-bundle: resolveStrategy prefer-newer-commit picks larger ct", () => {
+  assert.equal(resolveStrategy("prefer-newer-commit", 100, 200), "remote");
+  assert.equal(resolveStrategy("prefer-newer-commit", 200, 100), "local");
+  // Tie → local (Phase-0 semantic: don't disturb).
+  assert.equal(resolveStrategy("prefer-newer-commit", 100, 100), "local");
+});
+
+test("migration-bundle: resolveStrategy prefer-newer-commit treats local Infinity as wins", () => {
+  // AC 6b: untracked local card (Infinity) always wins over any remote ct.
+  assert.equal(resolveStrategy("prefer-newer-commit", Infinity, 12345), "local");
+  // Symmetric for remote.
+  assert.equal(resolveStrategy("prefer-newer-commit", 12345, Infinity), "remote");
+  // Both Infinity (degenerate) → local.
+  assert.equal(resolveStrategy("prefer-newer-commit", Infinity, Infinity), "local");
+});
+
+test("migration-bundle: resolveStrategy prefer-local / prefer-remote ignore commit times", () => {
+  assert.equal(resolveStrategy("prefer-local", 100, 999999), "local");
+  assert.equal(resolveStrategy("prefer-remote", 999999, 100), "remote");
+});
+
+// --------------------------------------------------------------------
+// 1. Privacy denylist module.
+
+test("privacy-denylist: canonical brand string is matched", () => {
+  const hit = findFirstMatch("This card mentions UOB explicitly.");
+  assert.ok(hit, "expected a match");
+  assert.equal(hit.name, "brand-bare");
+});
+
+test("privacy-denylist: case-insensitive — lowercase brand still matches", () => {
+  const hit = findFirstMatch("we worked at uob in 2022");
+  assert.ok(hit, "expected case-insensitive match");
+  assert.equal(hit.name, "brand-bare");
+});
+
+test("privacy-denylist: brand variant 'UOB Bank' matches via brand-bank pattern", () => {
+  const hit = findFirstMatch("UOB Bank had branches in 5 countries");
+  assert.ok(hit);
+  // Either brand-bare (matches "UOB") or brand-bank (matches the full
+  // form) is acceptable — the bare pattern fires first since it's listed
+  // first in DENYLIST_PATTERNS.
+  assert.ok(hit.name === "brand-bare" || hit.name === "brand-bank");
+});
+
+test("privacy-denylist: spaced-acronym variant 'U.O.B.' matches", () => {
+  const hit = findFirstMatch("U.O.B. Group rolled out a new product.");
+  assert.ok(hit, "expected variant match");
+});
+
+test("privacy-denylist: clean text returns null", () => {
+  assert.equal(findFirstMatch("a top ASEAN bank rolled out a mobile app"), null);
+  assert.equal(findFirstMatch(""), null);
+  assert.equal(findFirstMatch(null), null);
+});
+
+test("privacy-denylist: Best Foreign Bank in Malaysia award name matches", () => {
+  const hit = findFirstMatch("won Best Foreign Bank in Malaysia (Asian Banker 2022)");
+  assert.ok(hit);
+  assert.equal(hit.name, "award-best-foreign-bank-my");
+});
+
+// --------------------------------------------------------------------
+// 2. AC-4: migrate-out exits 0 and creates the target branch (via local
+// remote). Mirrors the spec verifier shape but uses local bare repo.
+
+test("AC-4: migrate-out --target-branch test-fixture-1 exits 0 and creates branch", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "awm-mig-ac4-"));
+  const root = join(tmp, "wm");
+  mkdirSync(join(root, "tier-b"), { recursive: true });
+  seedTierB(join(root, "tier-b"), [
+    { id: "ac4-1", topic: "demo", title: "x", pinned: true },
+    { id: "ac4-2", topic: "demo", title: "y", pinned: true },
+    { id: "ac4-3", topic: "demo", title: "z", pinned: true },
+  ]);
+  const { remoteUrl } = makeLocalRemote(tmp);
+  const clone = join(tmp, "migrate-clone");
+
+  const env = {
+    MIGRATE_REPO_REMOTE: remoteUrl,
+    MIGRATE_REPO_CLONE: clone,
+    MIGRATE_AUTHOR_NAME: "Test",
+    MIGRATE_AUTHOR_EMAIL: "test@test",
+  };
+  const old = saveEnv(Object.keys(env));
+  applyEnv(env);
+  try {
+    const r = await runMigrateOut({ root, clone, targetBranch: "test-fixture-1" });
+    assert.equal(r.exitCode, 0);
+    assert.equal(r.committed, true);
+    assert.equal(r.pushed, true);
+    assert.equal(r.branch, "test-fixture-1");
+
+    // ls-remote equivalent: query the bare repo for the branch ref.
+    const refs = execFileSync("git", ["ls-remote", remoteUrl, "refs/heads/test-fixture-1"], { encoding: "utf8" }).trim();
+    assert.match(refs, /^[0-9a-f]{40}\s+refs\/heads\/test-fixture-1$/, `expected branch ref, got: ${refs}`);
+  } finally {
+    restoreEnv(old);
+  }
+});
+
+// --------------------------------------------------------------------
+// 3. AC-5: migrate-in --strategy prefer-remote reproduces the fixture
+// tree-hash exactly (round-trip).
+
+test("AC-5: migrate-in reproduces fixture tree-hash with prefer-remote", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "awm-mig-ac5-"));
+  const root1 = join(tmp, "wm1");
+  mkdirSync(join(root1, "tier-b"), { recursive: true });
+  seedTierB(join(root1, "tier-b"), [
+    { id: "rt1", topic: "demo", title: "first", pinned: true },
+    { id: "rt2", topic: "policies", title: "second", pinned: true },
+  ]);
+  const fixtureHash = hashTierBTreeOf(join(root1, "tier-b"));
+
+  const { remoteUrl } = makeLocalRemote(tmp);
+  const cloneOut = join(tmp, "out-clone");
+  const cloneIn = join(tmp, "in-clone");
+  const root2 = join(tmp, "wm2");
+  mkdirSync(join(root2, "tier-b"), { recursive: true });
+
+  const env = {
+    MIGRATE_REPO_REMOTE: remoteUrl,
+    MIGRATE_AUTHOR_NAME: "Test",
+    MIGRATE_AUTHOR_EMAIL: "test@test",
+  };
+  const old = saveEnv(Object.keys(env));
+  applyEnv(env);
+  try {
+    // OUT.
+    const ro = await runMigrateOut({ root: root1, clone: cloneOut, targetBranch: "rt-branch" });
+    assert.equal(ro.exitCode, 0);
+
+    // IN, with prefer-remote so remote always wins. Fresh empty local.
+    const ri = await runMigrateIn({
+      root: root2,
+      clone: cloneIn,
+      fromBranch: "rt-branch",
+      strategy: "prefer-remote",
+    });
+    assert.equal(ri.exitCode, 0, `expected 0, got ${ri.exitCode} (${ri.error || ""})`);
+
+    const restoredHash = hashTierBTreeOf(join(root2, "tier-b"));
+    assert.equal(restoredHash, fixtureHash, "tree-hash equals fixture's after round-trip");
+  } finally {
+    restoreEnv(old);
+  }
+});
+
+// --------------------------------------------------------------------
+// 4. AC-7: round-trip preserves frontmatter + body byte-equal.
+
+test("AC-7: round-trip is byte-equal across migrate-out → migrate-in", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "awm-mig-ac7-"));
+  const root1 = join(tmp, "wm1");
+  mkdirSync(join(root1, "tier-b"), { recursive: true });
+  // Use deliberately wonky bytes — extra blank lines, trailing spaces, an
+  // odd unicode char — so any canonicalization would show up.
+  const oddBody = "## Decision\n  trailing-space   \n\nBody with em-dash — and 中文 字符.\n\n\n";
+  seedTierB(join(root1, "tier-b"), [{
+    id: "byte-1",
+    topic: "demo",
+    title: "byte fidelity",
+    pinned: true,
+    text: makeCard({ id: "byte-1", topic: "demo", title: "byte fidelity", pinned: true, body: oddBody }),
+  }]);
+
+  const fixtureBytes = readFileSync(
+    join(root1, "tier-b", "topics", "demo", "byte-1.md"),
+  );
+
+  const { remoteUrl } = makeLocalRemote(tmp);
+  const root2 = join(tmp, "wm2");
+  mkdirSync(join(root2, "tier-b"), { recursive: true });
+
+  const env = {
+    MIGRATE_REPO_REMOTE: remoteUrl,
+    MIGRATE_AUTHOR_NAME: "Test",
+    MIGRATE_AUTHOR_EMAIL: "test@test",
+  };
+  const old = saveEnv(Object.keys(env));
+  applyEnv(env);
+  try {
+    const ro = await runMigrateOut({
+      root: root1,
+      clone: join(tmp, "out-clone"),
+      targetBranch: "byte-branch",
+    });
+    assert.equal(ro.exitCode, 0);
+
+    const ri = await runMigrateIn({
+      root: root2,
+      clone: join(tmp, "in-clone"),
+      fromBranch: "byte-branch",
+      strategy: "prefer-remote",
+    });
+    assert.equal(ri.exitCode, 0);
+
+    const restoredBytes = readFileSync(
+      join(root2, "tier-b", "topics", "demo", "byte-1.md"),
+    );
+    assert.deepEqual(
+      Array.from(restoredBytes),
+      Array.from(fixtureBytes),
+      "round-trip is byte-equal",
+    );
+  } finally {
+    restoreEnv(old);
+  }
+});
+
+// --------------------------------------------------------------------
+// 5. AC-6: prefer-newer-commit, both-tracked. The remote-side commit is
+// strictly newer in seconds, so remote wins.
+
+test("AC-6: prefer-newer-commit both-tracked → newer side wins", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "awm-mig-ac6-"));
+  const root = join(tmp, "wm");
+  mkdirSync(join(root, "tier-b"), { recursive: true });
+  // Seed an older copy locally.
+  seedTierB(join(root, "tier-b"), [{
+    id: "conflict-1",
+    topic: "demo",
+    title: "OLD local",
+    pinned: true,
+  }]);
+  // Init a git repo at the WM root and commit so the local side has a ct.
+  gitInitAndCommit(root, "old commit");
+
+  // Sleep 2s (commit-time resolution is in seconds; we need a strict
+  // ordering across two commits).
+  await new Promise((r) => setTimeout(r, 2100));
+
+  // Prepare a "fresh remote" by seeding a fresher copy in a separate
+  // temp tier-b root, migrate-out it, then migrate-in.
+  const root2 = join(tmp, "wm2");
+  mkdirSync(join(root2, "tier-b"), { recursive: true });
+  seedTierB(join(root2, "tier-b"), [{
+    id: "conflict-1",
+    topic: "demo",
+    title: "NEW remote",
+    pinned: true,
+  }]);
+  const { remoteUrl } = makeLocalRemote(tmp);
+
+  const env = {
+    MIGRATE_REPO_REMOTE: remoteUrl,
+    MIGRATE_AUTHOR_NAME: "Test",
+    MIGRATE_AUTHOR_EMAIL: "test@test",
+  };
+  const old = saveEnv(Object.keys(env));
+  applyEnv(env);
+  try {
+    // Push the newer remote.
+    const ro = await runMigrateOut({
+      root: root2,
+      clone: join(tmp, "out-clone"),
+      targetBranch: "conflict-branch",
+    });
+    assert.equal(ro.exitCode, 0);
+
+    // Apply onto the older local with prefer-newer-commit.
+    const ri = await runMigrateIn({
+      root,
+      clone: join(tmp, "in-clone"),
+      fromBranch: "conflict-branch",
+      strategy: "prefer-newer-commit",
+    });
+    assert.equal(ri.exitCode, 0);
+
+    // Local card was overwritten by the newer remote.
+    const restored = readFileSync(
+      join(root, "tier-b", "topics", "demo", "conflict-1.md"),
+      "utf8",
+    );
+    assert.match(restored, /title:\s*NEW remote/);
+    assert.ok(!/title:\s*OLD local/.test(restored));
+  } finally {
+    restoreEnv(old);
+  }
+});
+
+// --------------------------------------------------------------------
+// 6. AC-6b: prefer-newer-commit, local-untracked. The local card has no
+// commit time (no .git in the WM root) so it MUST win over any remote ct.
+
+test("AC-6b: prefer-newer-commit preserves locally-untracked cards", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "awm-mig-ac6b-"));
+  const root = join(tmp, "wm");
+  mkdirSync(join(root, "tier-b"), { recursive: true });
+  // Local: untracked (no git init).
+  seedTierB(join(root, "tier-b"), [{
+    id: "untracked-1",
+    topic: "demo",
+    title: "PRESERVE local untracked",
+    pinned: true,
+  }]);
+
+  // Remote: create a NEW remote-side copy (different content) and push.
+  const root2 = join(tmp, "wm2");
+  mkdirSync(join(root2, "tier-b"), { recursive: true });
+  seedTierB(join(root2, "tier-b"), [{
+    id: "untracked-1",
+    topic: "demo",
+    title: "REMOTE side",
+    pinned: true,
+  }]);
+
+  const { remoteUrl } = makeLocalRemote(tmp);
+  const env = {
+    MIGRATE_REPO_REMOTE: remoteUrl,
+    MIGRATE_AUTHOR_NAME: "Test",
+    MIGRATE_AUTHOR_EMAIL: "test@test",
+  };
+  const old = saveEnv(Object.keys(env));
+  applyEnv(env);
+  try {
+    const ro = await runMigrateOut({
+      root: root2,
+      clone: join(tmp, "out-clone"),
+      targetBranch: "untracked-branch",
+    });
+    assert.equal(ro.exitCode, 0);
+
+    const ri = await runMigrateIn({
+      root,
+      clone: join(tmp, "in-clone"),
+      fromBranch: "untracked-branch",
+      strategy: "prefer-newer-commit",
+    });
+    assert.equal(ri.exitCode, 0);
+
+    // Local untracked card preserved (NOT overwritten by remote).
+    const restored = readFileSync(
+      join(root, "tier-b", "topics", "demo", "untracked-1.md"),
+      "utf8",
+    );
+    assert.match(restored, /title:\s*PRESERVE local untracked/);
+    assert.ok(!/title:\s*REMOTE side/.test(restored));
+  } finally {
+    restoreEnv(old);
+  }
+});
+
+// --------------------------------------------------------------------
+// 7. --include-non-pinned: non-pinned cards make it into the bundle.
+
+test("migrate-out: --include-non-pinned bundles unpinned cards", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "awm-mig-incl-"));
+  const root = join(tmp, "wm");
+  mkdirSync(join(root, "tier-b"), { recursive: true });
+  seedTierB(join(root, "tier-b"), [
+    { id: "p1", topic: "demo", title: "pinned", pinned: true },
+    { id: "n1", topic: "demo", title: "loose", pinned: false },
+  ]);
+  const { remoteUrl } = makeLocalRemote(tmp);
+
+  const env = {
+    MIGRATE_REPO_REMOTE: remoteUrl,
+    MIGRATE_AUTHOR_NAME: "Test",
+    MIGRATE_AUTHOR_EMAIL: "test@test",
+  };
+  const old = saveEnv(Object.keys(env));
+  applyEnv(env);
+  try {
+    // Without flag: only pinned should land.
+    const r1 = await runMigrateOut({
+      root,
+      clone: join(tmp, "clone1"),
+      targetBranch: "incl-pinned-only",
+    });
+    assert.equal(r1.exitCode, 0);
+    assert.equal(r1.bundled, 1);
+
+    // With flag: both land.
+    const r2 = await runMigrateOut({
+      root,
+      clone: join(tmp, "clone2"),
+      targetBranch: "incl-all",
+      includeNonPinned: true,
+    });
+    assert.equal(r2.exitCode, 0);
+    assert.equal(r2.bundled, 2);
+  } finally {
+    restoreEnv(old);
+  }
+});
+
+// --------------------------------------------------------------------
+// 8. AC-9b: privacy denylist rejects canonical and variant fixtures, no
+// branches are pushed.
+
+test("AC-9b: privacy denylist rejects canonical brand fixture, no push", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "awm-mig-priv-1-"));
+  const root = join(tmp, "wm");
+  mkdirSync(join(root, "tier-b"), { recursive: true });
+  // Card body contains the canonical regulated token.
+  seedTierB(join(root, "tier-b"), [{
+    id: "leak-1",
+    topic: "demo",
+    title: "harmless title",
+    pinned: true,
+    text: makeCard({
+      id: "leak-1",
+      topic: "demo",
+      title: "harmless title",
+      pinned: true,
+      body: "## Decision\nWe shipped a feature for UOB last quarter.\n",
+    }),
+  }]);
+  const { remoteUrl } = makeLocalRemote(tmp);
+
+  // Capture stderr written via the CLI.
+  let captured = "";
+  const origWrite = process.stderr.write.bind(process.stderr);
+  process.stderr.write = (chunk, ...rest) => {
+    captured += chunk?.toString?.() ?? String(chunk);
+    return true;
+  };
+
+  const env = {
+    MIGRATE_REPO_REMOTE: remoteUrl,
+    MIGRATE_AUTHOR_NAME: "Test",
+    MIGRATE_AUTHOR_EMAIL: "test@test",
+  };
+  const old = saveEnv(Object.keys(env));
+  applyEnv(env);
+  try {
+    const r = await runMigrateOut({
+      root,
+      clone: join(tmp, "clone"),
+      targetBranch: "test-privacy-rejection-1",
+    });
+    assert.notEqual(r.exitCode, 0, "expected non-zero exit for privacy block");
+    assert.equal(r.errClass, "privacy-block");
+    assert.match(captured, /PRIVACY-BLOCK/);
+
+    // Branch must not exist on remote.
+    const refs = execFileSync("git", ["ls-remote", remoteUrl, "refs/heads/test-privacy-rejection-1"], { encoding: "utf8" }).trim();
+    assert.equal(refs, "", "no branch should be pushed");
+  } finally {
+    process.stderr.write = origWrite;
+    restoreEnv(old);
+  }
+});
+
+test("AC-9b: privacy denylist rejects mixed-case/spaced brand variant fixture, no push", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "awm-mig-priv-2-"));
+  const root = join(tmp, "wm");
+  mkdirSync(join(root, "tier-b"), { recursive: true });
+  // Variant: lowercase + spacing form. The denylist must match
+  // case-insensitively per the privacy spec.
+  seedTierB(join(root, "tier-b"), [{
+    id: "leak-2",
+    topic: "demo",
+    title: "harmless title",
+    pinned: true,
+    text: makeCard({
+      id: "leak-2",
+      topic: "demo",
+      title: "harmless title",
+      pinned: true,
+      body: "## Decision\nWe partnered with u.o.b. group on a regional rollout.\n",
+    }),
+  }]);
+  const { remoteUrl } = makeLocalRemote(tmp);
+
+  let captured = "";
+  const origWrite = process.stderr.write.bind(process.stderr);
+  process.stderr.write = (chunk) => {
+    captured += chunk?.toString?.() ?? String(chunk);
+    return true;
+  };
+
+  const env = {
+    MIGRATE_REPO_REMOTE: remoteUrl,
+    MIGRATE_AUTHOR_NAME: "Test",
+    MIGRATE_AUTHOR_EMAIL: "test@test",
+  };
+  const old = saveEnv(Object.keys(env));
+  applyEnv(env);
+  try {
+    const r = await runMigrateOut({
+      root,
+      clone: join(tmp, "clone"),
+      targetBranch: "test-privacy-rejection-2",
+    });
+    assert.notEqual(r.exitCode, 0, "expected non-zero exit for variant privacy block");
+    assert.equal(r.errClass, "privacy-block");
+    assert.match(captured, /PRIVACY-BLOCK/);
+
+    const refs = execFileSync("git", ["ls-remote", remoteUrl, "refs/heads/test-privacy-rejection-2"], { encoding: "utf8" }).trim();
+    assert.equal(refs, "", "no branch should be pushed for variant");
+  } finally {
+    process.stderr.write = origWrite;
+    restoreEnv(old);
+  }
+});
+
+// --------------------------------------------------------------------
+// 9. Default branch refusal — never write to 'main' / 'master'.
+
+test("migrate-out: refuses to push to 'main' branch", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "awm-mig-prot-"));
+  const root = join(tmp, "wm");
+  mkdirSync(join(root, "tier-b"), { recursive: true });
+  seedTierB(join(root, "tier-b"), [{ id: "p1", topic: "demo", title: "x", pinned: true }]);
+  const r = await runMigrateOut({ root, clone: join(tmp, "clone"), targetBranch: "main" });
+  assert.notEqual(r.exitCode, 0);
+  assert.equal(r.errClass, "protected-branch");
+});
+
+test("migrate-out: refuses to push to 'master' branch", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "awm-mig-prot2-"));
+  const root = join(tmp, "wm");
+  mkdirSync(join(root, "tier-b"), { recursive: true });
+  seedTierB(join(root, "tier-b"), [{ id: "p1", topic: "demo", title: "x", pinned: true }]);
+  const r = await runMigrateOut({ root, clone: join(tmp, "clone"), targetBranch: "master" });
+  assert.notEqual(r.exitCode, 0);
+  assert.equal(r.errClass, "protected-branch");
+});
+
+// --------------------------------------------------------------------
+// Helper: tree-hash. Self-contained, sync, no external state.
+
+function hashTierBTreeOf(tierBRoot) {
+  const topics = join(tierBRoot, "topics");
+  const out = [];
+  if (!existsSync(topics)) return "EMPTY";
+  walk(topics);
+  out.sort((a, b) => (a.rel < b.rel ? -1 : a.rel > b.rel ? 1 : 0));
+  const h = createHash("sha256");
+  for (const e of out) {
+    h.update(e.rel);
+    h.update("\0");
+    h.update(e.bytes);
+    h.update("\0");
+  }
+  return h.digest("hex");
+
+  function walk(dir) {
+    let entries;
+    try { entries = importedFs.readdirSync(dir); } catch { return; }
+    for (const name of entries.sort()) {
+      const full = join(dir, name);
+      let st;
+      try { st = importedFs.statSync(full); } catch { continue; }
+      if (st.isDirectory()) walk(full);
+      else if (st.isFile() && name.endsWith(".md")) {
+        const rel = full.slice(topics.length + 1).split(sep).join("/");
+        out.push({ rel, bytes: readFileSync(full) });
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Two new CLI subcommands enabling cross-machine tier-b portability without ad-hoc bash drains:

- **`memory migrate-out [--target-branch N] [--include-non-pinned]`** — bundle local tier-b cards into a transport branch on the agent-working-memory-content backup repo. Default branch: `migration/<host-id>-<YYYY-MM-DD>`. Default filter: pinned only. Refuses to push to `main`/`master`. Privacy denylist pre-flight (PRIVACY-BLOCK on any regulated-token match — case-insensitive, covers brand variants).
- **`memory migrate-in [--from-branch N] [--strategy S]`** — apply a transport branch into local tier-b. Strategies: `prefer-local`, `prefer-remote`, `prefer-newer-commit` (default; per-file `git log -1 --format=%ct`, untracked-local = `Infinity` so freshest-on-disk wins per AC-6b).

Round-trip is byte-equal: both commands `cp` bytes; YAML is never re-parsed. Clones force `core.autocrlf=false` / `core.eol=lf` so byte-fidelity holds on Windows.

New files:
- `scripts/migrate-out.mjs`
- `scripts/migrate-in.mjs`
- `scripts/lib/migration-bundle.mjs` (host-id, branch naming, commit-time merge)
- `scripts/lib/privacy-denylist.mjs` — first callable artefact for the prose privacy spec; consumers: migrate-out today, ai-brain `/ship` as follow-up
- `tests/migrate.test.mjs` (22 tests covering AC-4/5/6/6b/7/9/9b)

Backwards compat: existing daily `working-memory-content-sync` cron is unchanged. New subcommands are additive.

Plan: `ai-brain/.ai-workspace/plans/2026-05-05-memory-portability-migration-and-durable-tooling.final.md`

## Test plan

- [x] `node --test tests/content-sync.test.mjs` — no regression (AC-8)
- [x] `node --test tests/migrate.test.mjs` — all 22 new cases pass (AC-9)
- [x] `npm test` — full 51-test suite passes locally
- [x] AC-4 verifier: `WORKING_MEMORY_ROOT=$tmpdir node src/memory-cli.mjs migrate-out --target-branch test-fixture-1` exits 0; `git ls-remote ...` returns SHA
- [x] AC-5 verifier: round-trip restores fixture tree-hash exactly with `--strategy prefer-remote`
- [x] AC-6 verifier: `prefer-newer-commit` both-tracked → newer wins
- [x] AC-6b verifier: `prefer-newer-commit` local-untracked → local preserved (Infinity rule)
- [x] AC-7 verifier: round-trip is byte-equal across migrate-out → migrate-in
- [x] AC-9b verifier: canonical AND variant privacy fixtures both rejected with non-zero exit + `PRIVACY-BLOCK` on stderr; no branches pushed

index-check: skip -- agent-working-memory repo, not ai-brain