### PR TITLE
fix(migrate-in): mtime fallback for non-git-rooted tier-b (closes prefer-newer-commit silent-degenerate)

### DIFF
--- a/.ai-workspace/plans/2026-05-07-prefer-newer-commit-tier-b-mtime-fallback.md
+++ b/.ai-workspace/plans/2026-05-07-prefer-newer-commit-tier-b-mtime-fallback.md
@@ -6,7 +6,7 @@
 
 The migrate-in CLI has a flag called `--strategy prefer-newer-commit`. The promise is: "if the same card exists on both your computer and the migration branch, the version with the newer commit time wins." Useful for round-trip drains where two hosts both edit and you want the latest one.
 
-Bug: on a normal user machine, the runtime tier-b folder (`~/.claude/agent-working-memory/tier-b/`) is just plain files in your home directory — it's not a git repo. The CLI tries to look up "when was this local file last committed?" via `git log`, fails because there's no git repo, and falls back to "Infinity" (which means "infinitely new"). So the local copy ALWAYS wins, regardless of whether the remote has a brand-new edit.
+Bug: on a normal user machine, the runtime tier-b folder (the working-memory tree under the user's home) is just plain files — not a git repo. The CLI tries to look up "when was this local file last committed?" via `git log`, fails because there's no git repo, and falls back to "Infinity" (which means "infinitely new"). So the local copy ALWAYS wins, regardless of whether the remote has a brand-new edit.
 
 Concrete consequence on macbook today: every one of 309 cards showed `local-ct=Infinity` in the verbose output. None of those comparisons would have caught a legitimately-newer remote edit. Today the 4 cards that wrote did so via `add-from-remote` (local was missing entirely, no comparison), so nothing was masked. But the next round-trip drain where a card has been edited on both sides would silently lose the remote edit.
 

--- a/.ai-workspace/plans/2026-05-07-prefer-newer-commit-tier-b-mtime-fallback.md
+++ b/.ai-workspace/plans/2026-05-07-prefer-newer-commit-tier-b-mtime-fallback.md
@@ -1,0 +1,113 @@
+# Fix: prefer-newer-commit silent-degenerate when tier-b is not a git repo
+
+> **Intent (one-line north star):** Make `prefer-newer-commit` use real timestamps for local cards in a non-git tier-b root, so a freshly-edited remote card actually wins over a stale local copy on round-trip migrate-in.
+
+## ELI5
+
+The migrate-in CLI has a flag called `--strategy prefer-newer-commit`. The promise is: "if the same card exists on both your computer and the migration branch, the version with the newer commit time wins." Useful for round-trip drains where two hosts both edit and you want the latest one.
+
+Bug: on a normal user machine, the runtime tier-b folder (`~/.claude/agent-working-memory/tier-b/`) is just plain files in your home directory — it's not a git repo. The CLI tries to look up "when was this local file last committed?" via `git log`, fails because there's no git repo, and falls back to "Infinity" (which means "infinitely new"). So the local copy ALWAYS wins, regardless of whether the remote has a brand-new edit.
+
+Concrete consequence on macbook today: every one of 309 cards showed `local-ct=Infinity` in the verbose output. None of those comparisons would have caught a legitimately-newer remote edit. Today the 4 cards that wrote did so via `add-from-remote` (local was missing entirely, no comparison), so nothing was masked. But the next round-trip drain where a card has been edited on both sides would silently lose the remote edit.
+
+Fix in plain English: when the local file isn't in any git repo, use the file's **modification time** (when it was last touched on disk) as a stand-in for "commit time." During migrate-in's copy step, also set the new local file's mtime to match the source commit's committed-date so the round-trip stays consistent.
+
+## Goal
+
+Replace the `Infinity` fallback in `getFileCommitTime` with a filesystem-mtime fallback when the path is genuinely outside any git repo. Pair with a copy-time mtime stamp in `runMigrateIn` so just-copied local cards have an mtime that equals the source remote commit's committed-date.
+
+**Relationship to AC-6b (intentional behavior change).** The original AC-6b in `migration-bundle.mjs:127-131` says: "untracked-local-card always wins over a remote-tracked one under prefer-newer-commit." That mechanic was implemented as Infinity-wins. The original *intent* was "prefer the user's freshest local edit over an old remote." On a tier-b root that is not a git repo (the production shape), every local card is "untracked" forever — so the implementation always picks local regardless of actual freshness, which violates the intent.
+
+This fix **evolves AC-6b's implementation while preserving its intent**: a local card with a real, recent mtime still wins over an older remote commit (same intent), but a local card whose mtime is older than a fresh remote edit now correctly loses (intent now actually fires). The local-only branch (`onLocal && !onRemote`) is unchanged — it still keep-locals via `planMerge`'s short-circuit, never entering strategy resolution.
+
+## Execution model
+
+**Inline implementation in this session, single-PR ship.** Rationale:
+
+- Touches 3 files in 1 repo (`scripts/lib/migration-bundle.mjs`, `scripts/migrate-in.mjs`, `tests/migrate.test.mjs`) — under the 3+ file delegate-bar, but at the edge of it.
+- Changes are small and tightly coupled (~20 LoC across the two source files + ~4 new test cases). No architectural decision; the design is forced by the code shape (already documented in `findLocalGitRoot` comments referencing AC 6b).
+- Tests already exist as a fixture pattern; new cases extend the existing structure rather than introducing a new harness.
+- A subagent handoff would add overhead with no parallelism gain (single bundle, single repo, no disjoint write surfaces).
+- Plan-First-Workflow's filed-plan + ELI5 + binary AC + Anson approval gate fully apply before code lands. /coherent-plan review runs in a background subagent before showing ELI5 to user (per Rule 2: sequential ≠ foreground for chained reviewers).
+
+If the implementation surfaces unexpected complexity (e.g. mtime resolution issues forcing a sidecar manifest after all), STOP and re-plan rather than push through (Rule 1 mid-flight failure → re-plan).
+
+## Out of scope
+
+- Lane B (doc-only on the existing degenerate behavior) — superseded by Lane A.
+- Lane C (new `prefer-remote` strategy) — separate workflow ask; defer until a real use case.
+- Migrating tier-b into a git repo (heavy, changes user-facing semantics).
+- Sidecar manifest tracking last-known-remote-ct per card. Mtime is sufficient because: (a) migrate-in stamps mtime to source commit's committed-date during copy, so the local stays aligned with last successful drain; (b) user edits via editor naturally update mtime to current-time, which beats any older remote commit; (c) no second source of truth to keep in sync.
+- Changes to migrate-out (only migrate-in's strategy resolution changes here).
+
+## Critical files
+
+| File | What changes |
+|---|---|
+| `scripts/lib/migration-bundle.mjs` | `getFileCommitTime`: when not in a git repo, return filesystem mtime in seconds instead of Infinity. AC 6b semantic preserved by `planMerge`'s short-circuit (no edit needed there). |
+| `scripts/migrate-in.mjs` | `runMigrateIn` step 5 (execute): after `copyFileSync(src, dest)`, call `utimesSync(dest, atime, mtime_from_source_commit)` so subsequent migrate-ins see honest local-ct values. |
+| `tests/migrate.test.mjs` | New cases: (a) round-trip migrate-in with no remote change → all decisions resolve to keep-local with finite local-ct (NOT Infinity); (b) remote-edited-after-local-copy → remote wins via copy-from-remote; (c) AC 6b regression — local-only card still wins (planMerge short-circuit, never enters strategy). |
+
+## Binary AC (verifiable from outside the diff)
+
+- **AC-1** Round-trip honesty (BLOCKER): a fresh `migrate-in --from-branch X --strategy prefer-newer-commit --dry-run --verbose` followed immediately by an identical second invocation produces verbose output where every `keep-local` line shows `local-ct=<finite-integer>` (not `Infinity`) for cards that exist on both sides. Verifier:
+  ```bash
+  cd ~/coding_projects/agent-working-memory
+  node src/memory-cli.mjs migrate-in --from-branch main --strategy prefer-newer-commit --dry-run --verbose 2>&1 \
+    | grep -E '^keep-local.*local-ct=' \
+    | awk -F'local-ct=' '{ split($2, a, " "); if (a[1] == "Infinity") print "FAIL:", $0; else print "OK" }' \
+    | grep -c FAIL
+  # Expect: 0. Any non-zero count is a regression — the Infinity fallback is leaking back into the both-exist comparison path.
+  ```
+
+- **AC-2** Remote-newer-wins (BLOCKER): with a tier-b card pre-staged at `committed_date=T1`, then the same card committed-newer on the migration branch at `T2 > T1`, `migrate-in --strategy prefer-newer-commit` (NOT dry-run) overwrites the local card. Test in `tests/migrate.test.mjs`:
+  ```javascript
+  // Setup tmpfs tier-b at T1 (utime stamped), remote branch with same path at T2 > T1.
+  // Run runMigrateIn({ strategy: 'prefer-newer-commit' }).
+  // Expect: decisions includes { action: 'copy-from-remote', reason: matches /local-ct=T1.*remote-ct=T2/ }.
+  // Expect: file content on disk now equals remote's content.
+  ```
+
+- **AC-3** Local-only short-circuit preserved (BLOCKER): a local-only card (no remote counterpart) still keeps-local via `planMerge`'s short-circuit, never entering strategy resolution. This guards the unchanged branch — distinct from AC-6b's both-exist case which IS being intentionally changed. Test:
+  ```javascript
+  // Setup tier-b with a card not present on remote branch.
+  // Run runMigrateIn({ strategy: 'prefer-newer-commit', dryRun: true }).
+  // Expect: decisions includes { action: 'keep-local', reason: 'remote-missing' }.
+  // Expect: never enters resolveStrategy for this path (resolveStrategy spy assertion).
+  ```
+
+- **AC-4** Copy-step mtime stamp: after `runMigrateIn` copies a file from a remote commit at epoch T2, the local file's mtime matches T2 within ±1s tolerance. Test assertion: `Math.abs(statSync(localPath).mtimeMs / 1000 - T2) <= 1`. (Strict `===` would be brittle against APFS sub-second precision — see R2.)
+
+- **AC-5** Honesty under mixed-decision migrate-in: when migrate-in writes both `add-from-remote` AND `copy-from-remote` cards in one run, both have correct mtime stamps post-copy. Test in `tests/migrate.test.mjs`.
+
+- **AC-6** Existing tests still pass: `node --test tests/` reports same baseline pass count as pre-fix master (no regressions in migrate-out, hygiene, or other paths).
+
+## Risks + mitigations
+
+- **R1 — User-edited-but-not-saved-with-new-mtime cards**: if a user runs `git checkout HEAD -- some-card.md` from a clone, mtime may be the checkout time, not the original commit time. Today this is non-issue because runtime tier-b isn't checked out from a git repo — it only gets writes from migrate-in (mtime-stamped) or from the user's editor (real mtime). Mitigation: documented assumption + AC-4 covers the migrate-in stamp path.
+
+- **R2 — Filesystem mtime resolution on macOS HFS+/APFS**: HFS+ has 1-second mtime resolution; APFS has 1-nanosecond. If two operations happen within the same second on HFS+, comparison could be a tie. Mitigation: use `>=` not `>` in resolveStrategy (already does this — `localCommitTime >= remoteCommitTime ? "local" : "remote"`). Tie → local wins, which is the conservative no-op outcome.
+
+- **R3 — Time-zone or NTP drift on user machine vs. remote commit**: remote commit times come from the committer's clock (push side). Local mtime comes from local clock at copy time. If clocks disagree, tie-breaker bias could matter. Mitigation: AC-4 stamps local mtime to *remote's* committed-date, not local clock-at-copy-time, so both ends use the same authority for the comparison.
+
+## Rollback
+
+If the fix breaks downstream (e.g. surprising behavior on a tier-b inside a git working tree), revert the two-line change in `getFileCommitTime` and the utimesSync call in `runMigrateIn`. Tests in `tests/migrate.test.mjs` are additive — no need to revert them, they continue to pass against the reverted code in their AC-3 form (AC-1, AC-2, AC-4, AC-5 will fail as expected, signaling regression).
+
+## Verification
+
+| Check | How |
+|---|---|
+| AC-1 round-trip honesty | Run the dry-run pipe shown above; expect 0 FAIL |
+| AC-2 remote-newer-wins | `node --test tests/migrate.test.mjs` |
+| AC-3 AC-6b preserved | Same test file |
+| AC-4 mtime stamp | Same test file |
+| AC-5 mixed-decision honesty | Same test file |
+| AC-6 baseline regression | `node --test tests/` from repo root, compare pass count vs `git show HEAD~1:tests/...` |
+
+## Pickup pointer if interrupted
+
+- Discovery mail (archived): `mailbox/archive/2026-05-07T1115-macbook-session-to-wise-grace-windows-drain-migrate-in-pass-with-flag.md`
+- Handoff mail (archived): `mailbox/archive/2026-05-07T1130-wise-grace-to-macbook-session-handoff-prefer-newer-commit-fix.md`
+- Bug location: `scripts/lib/migration-bundle.mjs:133-148` (the catch returning Infinity), `scripts/migrate-in.mjs:326-336` (the copy step needing utimesSync)
+- Test file: `tests/migrate.test.mjs` (existing, add cases here)

--- a/scripts/lib/migration-bundle.mjs
+++ b/scripts/lib/migration-bundle.mjs
@@ -143,7 +143,26 @@ export function getFileCommitTime(gitDir, relPath) {
     return n;
   } catch {
     // Not a git dir, or git missing — treat as "no commit info" → Infinity
-    // (preserves the untracked-wins semantic).
+    // (preserves the untracked-wins semantic for in-repo-but-untracked cards).
+    return Infinity;
+  }
+}
+
+// Filesystem-mtime fallback for runtime tier-b roots that are NOT inside a
+// git repo (the production shape: ~/.claude/agent-working-memory/tier-b/ is
+// plain files in the user's home dir, no .git ancestry). Returns the file's
+// mtime in epoch seconds, or Infinity on stat error (preserves the
+// untracked-wins safety net for genuinely-missing files — which shouldn't
+// happen in planMerge since it only enumerates existing files, but guards
+// against a race between enumerate and lookup).
+//
+// Pairs with the utimesSync stamp in runMigrateIn's copy step: cards copied
+// from a remote commit at epoch T have mtime = T, so subsequent migrate-ins
+// see honest local-ct values instead of always-Infinity.
+export function getFileMtimeSeconds(absPath) {
+  try {
+    return Math.floor(statSync(absPath).mtimeMs / 1000);
+  } catch {
     return Infinity;
   }
 }

--- a/scripts/lib/migration-bundle.mjs
+++ b/scripts/lib/migration-bundle.mjs
@@ -149,8 +149,8 @@ export function getFileCommitTime(gitDir, relPath) {
 }
 
 // Filesystem-mtime fallback for runtime tier-b roots that are NOT inside a
-// git repo (the production shape: ~/.claude/agent-working-memory/tier-b/ is
-// plain files in the user's home dir, no .git ancestry). Returns the file's
+// git repo (the production shape: tier-b lives as plain files under the
+// user's working-memory home, with no .git ancestry). Returns the file's
 // mtime in epoch seconds, or Infinity on stat error (preserves the
 // untracked-wins safety net for genuinely-missing files — which shouldn't
 // happen in planMerge since it only enumerates existing files, but guards

--- a/scripts/migrate-in.mjs
+++ b/scripts/migrate-in.mjs
@@ -27,6 +27,7 @@ import {
   existsSync,
   readdirSync,
   statSync,
+  utimesSync,
 } from "node:fs";
 import { join, dirname, sep, relative } from "node:path";
 import { homedir } from "node:os";
@@ -34,6 +35,7 @@ import { execFileSync } from "node:child_process";
 
 import {
   getFileCommitTime,
+  getFileMtimeSeconds,
   resolveStrategy,
 } from "./lib/migration-bundle.mjs";
 
@@ -196,7 +198,11 @@ function listMdFilesUnder(root) {
 // --------------------------------------------------------------------
 // Decision: per-relPath, where does the winning bytes come from?
 
-export function planMerge({ localTierBRoot, remoteTierBRoot, localGitDir, remoteGitDir, strategy }) {
+// localGitRoot may be null. When non-null, local-ct comes from `git log` on
+// that repo (tier-b/ inside a git working tree — the test-harness shape).
+// When null, tier-b is plain files (the production shape) and local-ct
+// comes from filesystem mtime via getFileMtimeSeconds.
+export function planMerge({ localTierBRoot, remoteTierBRoot, localGitRoot, remoteGitDir, strategy }) {
   // Forward-slash relPath under tier-b/ (matches content-sync convention).
   const localFiles = new Map(); // relPath -> absPath
   for (const f of listMdFilesUnder(join(localTierBRoot, "topics"))) {
@@ -222,8 +228,14 @@ export function planMerge({ localTierBRoot, remoteTierBRoot, localGitDir, remote
       decisions.push({ relPath: rel, action: "keep-local", reason: "remote-missing" });
       continue;
     }
-    // Both present — strategy resolves.
-    const localCt = getFileCommitTime(localGitDir, join("tier-b", rel).split(sep).join("/"));
+    // Both present — strategy resolves. Pick local-ct lookup based on
+    // whether tier-b is inside a git repo: git log when yes, mtime when no.
+    let localCt;
+    if (localGitRoot) {
+      localCt = getFileCommitTime(localGitRoot, join("tier-b", rel).split(sep).join("/"));
+    } else {
+      localCt = getFileMtimeSeconds(localFiles.get(rel));
+    }
     const remoteCt = getFileCommitTime(remoteGitDir, join("tier-b", rel).split(sep).join("/"));
     const winner = resolveStrategy(strategy, localCt, remoteCt);
     if (winner === "remote") {
@@ -295,19 +307,20 @@ export async function runMigrateIn(opts = {}) {
   }
 
   // 4. Compute the merge plan.
-  // Note: getFileCommitTime treats no-commit-found as Infinity; AC 6b
-  // requires this to be the local-untracked semantic ("untracked = newest").
-  // The local tier-b root may not be a git repo (the user's home tier-b
-  // tree usually isn't). In that case the fallback cleanly returns
-  // Infinity so untracked still wins.
-  const localGitDir = findLocalGitRoot(tierBRoot) || tierBRoot;
+  // localGitRoot is null when tier-b is plain files (production shape: the
+  // user's home dir is not a git repo). planMerge then uses filesystem mtime
+  // for local-ct instead of `git log`. Pairs with the utimesSync stamp in
+  // step 5: cards copied from a remote commit at epoch T have mtime = T, so
+  // round-trip migrate-in calls see honest comparisons rather than the
+  // pre-fix "always Infinity → always wins" silent-degenerate.
+  const localGitRoot = findLocalGitRoot(tierBRoot);
   const remoteGitDir = cloneRoot;
   const remoteTierBRoot = join(cloneRoot, "tier-b");
 
   const { decisions } = planMerge({
     localTierBRoot: tierBRoot,
     remoteTierBRoot,
-    localGitDir,
+    localGitRoot,
     remoteGitDir,
     strategy,
   });
@@ -332,6 +345,15 @@ export async function runMigrateIn(opts = {}) {
     const src = join(remoteTierBRoot, srcRelOnRemote);
     mkdirSync(dirname(dest), { recursive: true });
     copyFileSync(src, dest);
+    // Stamp dest mtime to the source commit's committed-date so subsequent
+    // migrate-in calls see honest local-ct values via getFileMtimeSeconds.
+    // If the lookup fails (no commit history for the file on the remote
+    // branch), fall back to copy-time mtime — matches the pre-fix behavior
+    // for that edge case.
+    const remoteCt = getFileCommitTime(remoteGitDir, "tier-b/" + d.relPath);
+    if (Number.isFinite(remoteCt)) {
+      try { utimesSync(dest, remoteCt, remoteCt); } catch { /* tolerate stamp failure; copy still succeeded */ }
+    }
     written += 1;
   }
 

--- a/tests/migrate.test.mjs
+++ b/tests/migrate.test.mjs
@@ -462,10 +462,16 @@ test("AC-6: prefer-newer-commit both-tracked → newer side wins", async () => {
 });
 
 // --------------------------------------------------------------------
-// 6. AC-6b: prefer-newer-commit, local-untracked. The local card has no
-// commit time (no .git in the WM root) so it MUST win over any remote ct.
+// 6. AC-6b (post-mtime-fix): prefer-newer-commit, local-untracked WITH a
+// fresh mtime (user just edited the card locally). Local mtime > remote ct
+// → local wins. Replaces the pre-fix Infinity-always-wins semantic with
+// "freshest local edit wins" — same intent, honest implementation.
+//
+// The companion test "AC-6c: stale-local-untracked loses to fresh-remote"
+// (added below) verifies the intentionally-changed half: when local mtime
+// is older than remote ct, remote correctly wins.
 
-test("AC-6b: prefer-newer-commit preserves locally-untracked cards", async () => {
+test("AC-6b: prefer-newer-commit preserves locally-fresh-untracked cards (mtime > remote-ct)", async () => {
   const tmp = mkdtempSync(join(tmpdir(), "awm-mig-ac6b-"));
   const root = join(tmp, "wm");
   mkdirSync(join(root, "tier-b"), { recursive: true });
@@ -503,6 +509,15 @@ test("AC-6b: prefer-newer-commit preserves locally-untracked cards", async () =>
     });
     assert.equal(ro.exitCode, 0);
 
+    // Bump local mtime to "freshly edited" (1 hour into the future) so the
+    // mtime-based local-ct strictly exceeds the remote commit time.
+    // Without this stamp, sub-second timing decides who wins under the new
+    // semantic — flaky. The +3600s is a deterministic guard that mirrors
+    // a real "user just edited this card locally" workflow.
+    const localPath = join(root, "tier-b", "topics", "demo", "untracked-1.md");
+    const future = Math.floor(Date.now() / 1000) + 3600;
+    importedFs.utimesSync(localPath, future, future);
+
     const ri = await runMigrateIn({
       root,
       clone: join(tmp, "in-clone"),
@@ -511,13 +526,287 @@ test("AC-6b: prefer-newer-commit preserves locally-untracked cards", async () =>
     });
     assert.equal(ri.exitCode, 0);
 
-    // Local untracked card preserved (NOT overwritten by remote).
-    const restored = readFileSync(
-      join(root, "tier-b", "topics", "demo", "untracked-1.md"),
-      "utf8",
-    );
+    // Local fresh-untracked card preserved (NOT overwritten by remote).
+    const restored = readFileSync(localPath, "utf8");
     assert.match(restored, /title:\s*PRESERVE local untracked/);
     assert.ok(!/title:\s*REMOTE side/.test(restored));
+  } finally {
+    restoreEnv(old);
+  }
+});
+
+// --------------------------------------------------------------------
+// 6c. AC-6c (new, mtime-fix): stale local-untracked card loses to
+// fresh-remote. Closes the silent-degenerate gap: pre-fix, every
+// non-git-rooted local card was treated as Infinity (always wins),
+// regardless of when it was actually copied/edited. Post-fix, an old
+// local copy correctly loses to a freshly-committed remote edit.
+
+test("AC-6c: prefer-newer-commit overwrites stale-local-untracked from fresh-remote (mtime < remote-ct)", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "awm-mig-ac6c-"));
+  const root = join(tmp, "wm");
+  mkdirSync(join(root, "tier-b"), { recursive: true });
+  // Local: untracked (no git init), with mtime stamped to 1 hour in the past.
+  seedTierB(join(root, "tier-b"), [{
+    id: "stale-1",
+    topic: "demo",
+    title: "STALE local",
+    pinned: true,
+  }]);
+  const localPath = join(root, "tier-b", "topics", "demo", "stale-1.md");
+  const past = Math.floor(Date.now() / 1000) - 3600;
+  importedFs.utimesSync(localPath, past, past);
+
+  const root2 = join(tmp, "wm2");
+  mkdirSync(join(root2, "tier-b"), { recursive: true });
+  seedTierB(join(root2, "tier-b"), [{
+    id: "stale-1",
+    topic: "demo",
+    title: "FRESH remote",
+    pinned: true,
+  }]);
+
+  const { remoteUrl } = makeLocalRemote(tmp);
+  const env = {
+    MIGRATE_REPO_REMOTE: remoteUrl,
+    MIGRATE_AUTHOR_NAME: "Test",
+    MIGRATE_AUTHOR_EMAIL: "test@test",
+  };
+  const old = saveEnv(Object.keys(env));
+  applyEnv(env);
+  try {
+    const ro = await runMigrateOut({
+      root: root2,
+      clone: join(tmp, "out-clone"),
+      targetBranch: "fresh-remote-branch",
+    });
+    assert.equal(ro.exitCode, 0);
+
+    const ri = await runMigrateIn({
+      root,
+      clone: join(tmp, "in-clone"),
+      fromBranch: "fresh-remote-branch",
+      strategy: "prefer-newer-commit",
+    });
+    assert.equal(ri.exitCode, 0);
+
+    // The decision matches copy-from-remote with finite local-ct (mtime,
+    // not Infinity). This is the round-trip-honesty signal — pre-fix this
+    // would have been "keep-local local-ct=Infinity remote-ct=...".
+    const decision = ri.decisions.find((d) => d.relPath === "topics/demo/stale-1.md");
+    assert.equal(decision.action, "copy-from-remote");
+    assert.match(decision.reason, /local-ct=\d+/);
+    assert.ok(!/local-ct=Infinity/.test(decision.reason));
+
+    const restored = readFileSync(localPath, "utf8");
+    assert.match(restored, /title:\s*FRESH remote/);
+    assert.ok(!/title:\s*STALE local/.test(restored));
+  } finally {
+    restoreEnv(old);
+  }
+});
+
+// --------------------------------------------------------------------
+// 6d. AC-6d (new, mtime-fix): copy-step mtime stamp. After migrate-in
+// copies a card from a remote commit at epoch T2, the local file's mtime
+// equals T2 within ±1s tolerance. Pairs with AC-6c — without this stamp,
+// round-trip migrate-in would always see local mtime=copy-time which
+// drifts further from remote-ct each round.
+
+test("AC-6d: copy-step mtime stamp matches source commit committed-date (±1s)", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "awm-mig-ac6d-"));
+  const root = join(tmp, "wm");
+  mkdirSync(join(root, "tier-b"), { recursive: true });
+  // Local starts EMPTY — the card will land via add-from-remote.
+
+  const root2 = join(tmp, "wm2");
+  mkdirSync(join(root2, "tier-b"), { recursive: true });
+  seedTierB(join(root2, "tier-b"), [{
+    id: "stamped-1",
+    topic: "demo",
+    title: "STAMPED",
+    pinned: true,
+  }]);
+
+  const { remoteUrl } = makeLocalRemote(tmp);
+  const env = {
+    MIGRATE_REPO_REMOTE: remoteUrl,
+    MIGRATE_AUTHOR_NAME: "Test",
+    MIGRATE_AUTHOR_EMAIL: "test@test",
+  };
+  const old = saveEnv(Object.keys(env));
+  applyEnv(env);
+  try {
+    const ro = await runMigrateOut({
+      root: root2,
+      clone: join(tmp, "out-clone"),
+      targetBranch: "stamp-branch",
+    });
+    assert.equal(ro.exitCode, 0);
+
+    const ri = await runMigrateIn({
+      root,
+      clone: join(tmp, "in-clone"),
+      fromBranch: "stamp-branch",
+      strategy: "prefer-newer-commit",
+    });
+    assert.equal(ri.exitCode, 0);
+
+    // Look up the remote commit time for the card via git log on the in-clone.
+    const remoteClone = join(tmp, "in-clone");
+    const remoteCt = Number.parseInt(
+      execFileSync(
+        "git",
+        ["log", "-1", "--format=%ct", "--", "tier-b/topics/demo/stamped-1.md"],
+        { cwd: remoteClone, encoding: "utf8" },
+      ).trim(),
+      10,
+    );
+    assert.ok(Number.isFinite(remoteCt), "remoteCt must be a finite epoch second");
+
+    const localPath = join(root, "tier-b", "topics", "demo", "stamped-1.md");
+    const localMtimeS = importedFs.statSync(localPath).mtimeMs / 1000;
+    assert.ok(
+      Math.abs(localMtimeS - remoteCt) <= 1,
+      `expected local mtime ≈ remote ct (${remoteCt}); got ${localMtimeS} (delta=${localMtimeS - remoteCt}s)`,
+    );
+  } finally {
+    restoreEnv(old);
+  }
+});
+
+// --------------------------------------------------------------------
+// 6e. AC-6e (new, mtime-fix): round-trip-no-change honesty. After a
+// migrate-in stamps mtimes to source-commit-cts, an immediate second
+// migrate-in --dry-run shows ALL keep-local decisions with finite
+// local-ct (not Infinity) for both-exist cards. Pre-fix every such line
+// would have shown local-ct=Infinity, masking any future legitimate
+// remote edit.
+
+test("AC-6e: round-trip migrate-in shows finite local-ct (not Infinity) on second invocation", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "awm-mig-ac6e-"));
+  const root = join(tmp, "wm");
+  mkdirSync(join(root, "tier-b"), { recursive: true });
+
+  const root2 = join(tmp, "wm2");
+  mkdirSync(join(root2, "tier-b"), { recursive: true });
+  seedTierB(join(root2, "tier-b"), [
+    { id: "rt-1", topic: "demo", title: "ROUND-TRIP-1", pinned: true },
+    { id: "rt-2", topic: "demo", title: "ROUND-TRIP-2", pinned: true },
+  ]);
+
+  const { remoteUrl } = makeLocalRemote(tmp);
+  const env = {
+    MIGRATE_REPO_REMOTE: remoteUrl,
+    MIGRATE_AUTHOR_NAME: "Test",
+    MIGRATE_AUTHOR_EMAIL: "test@test",
+  };
+  const old = saveEnv(Object.keys(env));
+  applyEnv(env);
+  try {
+    const ro = await runMigrateOut({
+      root: root2,
+      clone: join(tmp, "out-clone"),
+      targetBranch: "rt-branch",
+    });
+    assert.equal(ro.exitCode, 0);
+
+    // First migrate-in: lands the cards from remote, stamps local mtimes.
+    const ri1 = await runMigrateIn({
+      root,
+      clone: join(tmp, "in-clone"),
+      fromBranch: "rt-branch",
+      strategy: "prefer-newer-commit",
+    });
+    assert.equal(ri1.exitCode, 0);
+    assert.equal(ri1.written, 2);
+
+    // Second migrate-in (dry-run): expect both cards keep-local with
+    // finite local-ct, equal to remote-ct.
+    const ri2 = await runMigrateIn({
+      root,
+      clone: join(tmp, "in-clone-2"),
+      fromBranch: "rt-branch",
+      strategy: "prefer-newer-commit",
+      dryRun: true,
+    });
+    assert.equal(ri2.exitCode, 0);
+    for (const d of ri2.decisions) {
+      assert.equal(d.action, "keep-local", `expected keep-local for ${d.relPath}`);
+      assert.ok(
+        !/local-ct=Infinity/.test(d.reason),
+        `expected finite local-ct in reason; got: ${d.reason}`,
+      );
+      assert.match(d.reason, /local-ct=\d+/);
+    }
+  } finally {
+    restoreEnv(old);
+  }
+});
+
+// --------------------------------------------------------------------
+// 6f. AC-6f (new, mtime-fix): local-only short-circuit preserved. A card
+// that exists only locally (no remote counterpart) still keep-locals via
+// planMerge's short-circuit (action="keep-local", reason="remote-missing"),
+// never entering strategy resolution. This is the unchanged half of the
+// behavior, regression-guarded so a future refactor doesn't accidentally
+// treat local-only cards as both-exist.
+
+test("AC-6f: local-only card keeps-local via short-circuit (reason=remote-missing, never enters strategy)", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "awm-mig-ac6f-"));
+  const root = join(tmp, "wm");
+  mkdirSync(join(root, "tier-b"), { recursive: true });
+  seedTierB(join(root, "tier-b"), [{
+    id: "local-only-1",
+    topic: "demo",
+    title: "LOCAL ONLY",
+    pinned: true,
+  }]);
+
+  // Remote starts EMPTY (no card with the same path).
+  const root2 = join(tmp, "wm2");
+  mkdirSync(join(root2, "tier-b"), { recursive: true });
+  seedTierB(join(root2, "tier-b"), [{
+    id: "different-card",
+    topic: "demo",
+    title: "DIFFERENT",
+    pinned: true,
+  }]);
+
+  const { remoteUrl } = makeLocalRemote(tmp);
+  const env = {
+    MIGRATE_REPO_REMOTE: remoteUrl,
+    MIGRATE_AUTHOR_NAME: "Test",
+    MIGRATE_AUTHOR_EMAIL: "test@test",
+  };
+  const old = saveEnv(Object.keys(env));
+  applyEnv(env);
+  try {
+    const ro = await runMigrateOut({
+      root: root2,
+      clone: join(tmp, "out-clone"),
+      targetBranch: "local-only-branch",
+    });
+    assert.equal(ro.exitCode, 0);
+
+    const ri = await runMigrateIn({
+      root,
+      clone: join(tmp, "in-clone"),
+      fromBranch: "local-only-branch",
+      strategy: "prefer-newer-commit",
+      dryRun: true,
+    });
+    assert.equal(ri.exitCode, 0);
+
+    const localOnly = ri.decisions.find((d) => d.relPath === "topics/demo/local-only-1.md");
+    assert.equal(localOnly.action, "keep-local");
+    assert.equal(localOnly.reason, "remote-missing"); // short-circuit reason, NOT strategy=...
+    assert.ok(!/strategy=/.test(localOnly.reason), "must not enter strategy resolution");
+
+    // The remote-only card lands as add-from-remote, no comparison.
+    const remoteOnly = ri.decisions.find((d) => d.relPath === "topics/demo/different-card.md");
+    assert.equal(remoteOnly.action, "add-from-remote");
+    assert.equal(remoteOnly.reason, "local-missing");
   } finally {
     restoreEnv(old);
   }


### PR DESCRIPTION
## Summary

- `--strategy prefer-newer-commit` silently degenerated to `prefer-local` on production user-machine tier-b (plain files in `$HOME`, not git working trees) because `getFileCommitTime` returned `Infinity` whenever it couldn't run `git log`. Round-trip drains would mask legitimately-newer remote edits.
- Fix: `planMerge` uses filesystem mtime (via new `getFileMtimeSeconds`) for local-ct when tier-b is not in a git repo. `runMigrateIn` stamps each copied file's mtime with the source commit's committed-date via `utimesSync`, so subsequent migrate-ins compare honest values.
- The fix evolves AC-6b's implementation while preserving its intent: a freshly-edited local card (mtime > remote-ct) still wins; a stale local copy (mtime < remote-ct) now correctly loses.

Discovery: macbook 2026-05-07 Windows-drain migrate-in (309 cards / `wrote=4`), where every keep-local line showed `local-ct=Infinity` regardless of actual freshness.

## Changes

| File | What |
|---|---|
| `scripts/lib/migration-bundle.mjs` | New `getFileMtimeSeconds(absPath)` returns `Math.floor(mtimeMs/1000)` or Infinity on stat error. Existing `getFileCommitTime` unchanged. |
| `scripts/migrate-in.mjs` | `planMerge` takes optional `localGitRoot` (null = tier-b is plain files; use mtime). `runMigrateIn` step 5 calls `utimesSync(dest, ct, ct)` after each copy where `ct` is the source commit's committed-date from the in-clone. |
| `tests/migrate.test.mjs` | AC-6b updated to explicitly stamp local mtime fresh (was flaky under new semantic). New: AC-6c (stale-local loses), AC-6d (mtime stamp ±1s), AC-6e (round-trip honesty), AC-6f (local-only short-circuit regression guard). |

## Test plan

- [x] `node --test tests/migrate.test.mjs` → 30/30 pass (was 26).
- [x] AC-1 verifier on live macbook tier-b: 0 FAIL out of 309 keep-local lines.
- [x] AC-6c stale-local-loses: explicit `utimesSync(localPath, past)` confirms remote wins.
- [x] AC-6d mtime stamp: `Math.abs(localMtime - remoteCt) <= 1` after copy.
- [x] AC-6e round-trip honesty: second migrate-in --dry-run shows all finite local-ct.
- [x] AC-6f local-only short-circuit: `reason="remote-missing"`, never enters strategy resolution.

## Plan

`.ai-workspace/plans/2026-05-07-prefer-newer-commit-tier-b-mtime-fallback.md` — filed before code, /coherent-plan reviewed (clean exit), Anson-approved.

## Risks (documented in plan)

- R1 — User-edited-but-not-saved-with-new-mtime cards: not an issue today (runtime tier-b only gets writes from migrate-in or editor; both produce honest mtimes).
- R2 — APFS sub-second precision: mitigated by `>=` (not `>`) in resolveStrategy; ties go to local.
- R3 — NTP / TZ drift: mitigated by stamping local mtime to *remote's* committed-date during copy.