### PR TITLE
feat(ship): adopt /ship Stage 5.6 mechanical privacy gate (self-vendor)

### DIFF
--- a/.ai-workspace/plans/2026-05-07-stage-5-6-privacy-gate-adoption.md
+++ b/.ai-workspace/plans/2026-05-07-stage-5-6-privacy-gate-adoption.md
@@ -1,0 +1,121 @@
+# Adopt /ship Stage 5.6 mechanical privacy gate in agent-working-memory
+
+> **Intent (one-line north star):** Make /ship Stage 5.6 actually fire on agent-working-memory PRs by committing the gate runner + a self-pointing provenance, so privacy leaks are caught mechanically (P6/P13, ~90-100% compliance) instead of by manual cold-eyes review (F2, ~17% compliance).
+
+## ELI5
+
+`/ship` (the global PR-merge pipeline) has a step called Stage 5.6. It scans 5 surfaces of every PR — body, title, commit messages, branch name, diff content — for the regulated employer-brand token. If it finds one, the merge is blocked. This catches the "I accidentally pasted UOB into a plan file" class of mistake automatically.
+
+For Stage 5.6 to fire, /ship looks for a script at `<repo>/lib/privacy-denylist-gate.mjs`. ai-brain has it. agent-working-memory does NOT — so today's PR #28 ship card showed `privacyDenylistGate: n/a-not-installed` and the gate skipped. Three plan-file leaks of the regulated token went uncaught by mechanism and were caught only by the executor's manual judgment during PR #28 ship review.
+
+Fix: copy ai-brain's gate scaffolding into agent-working-memory's `lib/` directory. Three new files:
+
+1. `lib/privacy-denylist.mjs` — vendored byte-for-byte from `scripts/lib/privacy-denylist.mjs` (same repo's source).
+2. `lib/privacy-denylist.provenance.json` — provenance pointing at the in-repo source (self-vendoring), with current sha256.
+3. `lib/privacy-denylist-gate.mjs` — copied from ai-brain unchanged (485 LoC), except for one allowlist addition (`scripts/lib/privacy-denylist.mjs`) so editing the source itself doesn't self-block.
+
+Plus tests adapted from ai-brain's `tests/ship/privacy-denylist-gate*.test.mjs` (110 tests).
+
+## Goal
+
+After this ships, `/ship` Stage 5.6 fires on every agent-working-memory PR with the same five-surface gate ai-brain has. PR #28's "3 plan-file leaks caught by judgment" failure mode becomes mechanically impossible: any such leak would set Stage 5.6's sentinel to `aborted-block` and refuse the merge.
+
+The repo becomes its own first-vendoring-consumer of `privacy-denylist.mjs`. This is a deliberate self-reference — agent-working-memory IS the source, but `/ship` Stage 5.6's contract requires the gate at `lib/privacy-denylist-gate.mjs` (hardcoded path). Vendoring the source into `lib/` mirrors ai-brain's shape and keeps the gate's existing import (`./privacy-denylist.mjs`) unchanged.
+
+## Execution model
+
+**Inline implementation in this session, single-PR ship.** Rationale:
+
+- Touches 3 new files in `lib/` + 2 new test files + 1 ALLOWLIST_GLOBS line in the vendored gate. No architectural decision; the contract is set by /ship Stage 5.6's hardcoded path/import.
+- Bulk of the code is byte-for-byte vendoring (485 LoC gate + ~110 LoC tests, all from ai-brain). Net new logic ~5 lines.
+- Existing tests already cover the gate's behaviour in ai-brain (10 PASS / 0 FAIL). The "adopt verbatim" path means I'm reusing that test coverage — a subagent handoff would just duplicate effort.
+- Single-bundle change in one repo, no parallelism gain from /auto-flow. /coherent-plan runs as the only review.
+- Plan-First-Workflow + ELI5 + Rule 15 wait gate fully apply before code lands.
+
+If integrity-check semantics surface a complication (the self-vendoring pattern hits an edge case where the gate refuses to run because of provenance shape), STOP and re-plan rather than push through.
+
+## Out of scope
+
+- **Shape B (pre-push git hook)** — defer until Shape A is in production and we observe whether non-/ship pushes need separate gating. /ship Stage 5.6 is the documented mechanism; pushing outside /ship is rare.
+- **Adapting the gate to import from `scripts/lib/`** instead of vendoring — would diverge from ai-brain's shape unnecessarily. The cost of one duplicate file in `lib/` is small; the benefit of shape-parity (same allowlist regexes, same provenance check, same audit log entries) is large.
+- **Changing the source `scripts/lib/privacy-denylist.mjs`** — not touched. The vendored copy starts byte-equal.
+- **Test surface beyond ai-brain's 110-test coverage** — the gate's behaviour is identical to ai-brain's, so ai-brain's tests cover correctness. agent-working-memory adds a single self-vendor sanity test (provenance points at the right path; sha256 matches).
+- **Regenerating ai-brain's vendored copy** — this PR doesn't touch ai-brain. ai-brain's vendor stays at its current commit (`88b71434`).
+
+## Critical files
+
+| File | Provenance | Status |
+|---|---|---|
+| `lib/privacy-denylist.mjs` | Byte-equal copy of `scripts/lib/privacy-denylist.mjs` | NEW (vendored — same repo, self-reference) |
+| `lib/privacy-denylist.provenance.json` | Self-referencing provenance: `upstream_repo` = this repo, `upstream_commit` = HEAD before this PR, `upstream_path` = `scripts/lib/privacy-denylist.mjs`, `sha256` = sha256 of the source | NEW |
+| `lib/privacy-denylist-gate.mjs` | Byte-equal copy from `ai-brain/lib/privacy-denylist-gate.mjs` | NEW |
+| Gate's `ALLOWLIST_GLOBS` | Add `scripts/lib/privacy-denylist.mjs` to the existing 6-entry list | 1 LINE EDIT in the vendored gate |
+| `tests/privacy-denylist-gate.test.mjs` | Adapted from `ai-brain/tests/ship/privacy-denylist-gate.test.mjs` — same imports, repo-root-relative paths reused | NEW |
+| `tests/privacy-denylist-gate-allowlist.test.mjs` | Adapted from `ai-brain/tests/ship/privacy-denylist-gate-allowlist.test.mjs` | NEW |
+
+## Binary AC (verifiable from outside the diff)
+
+- **AC-1 Gate present at canonical path (BLOCKER):** `test -f lib/privacy-denylist-gate.mjs && test -f lib/privacy-denylist.mjs && test -f lib/privacy-denylist.provenance.json` — all three exit 0.
+- **AC-2 Provenance integrity (BLOCKER):**
+  ```bash
+  node -e '
+    import("crypto").then(({createHash}) => {
+      import("fs").then(({readFileSync}) => {
+        const expected = JSON.parse(readFileSync("lib/privacy-denylist.provenance.json", "utf8")).sha256;
+        const actual = createHash("sha256").update(readFileSync("lib/privacy-denylist.mjs")).digest("hex");
+        if (actual !== expected) { console.error("MISMATCH:", actual, "vs", expected); process.exit(1); }
+        console.log("MATCH");
+      });
+    });
+  '
+  ```
+  Expect: `MATCH`.
+- **AC-3 Self-vendor sanity (BLOCKER):** `lib/privacy-denylist.mjs` and `scripts/lib/privacy-denylist.mjs` are byte-equal: `diff lib/privacy-denylist.mjs scripts/lib/privacy-denylist.mjs` exits 0 with empty output.
+- **AC-4 Allowlist includes source path (BLOCKER):** `grep -F "scripts/lib/privacy-denylist.mjs" lib/privacy-denylist-gate.mjs` returns exactly 1 line. (Verifies the allowlist addition is in the gate code, so editing the source doesn't self-block diff-content surface.)
+- **AC-5 Gate fires green on this PR's own surfaces (BLOCKER, post-PR-create):** Once the PR is created (after `gh pr create` succeeds), run:
+  ```bash
+  node lib/privacy-denylist-gate.mjs run --pr-number {THIS_PR}
+  ```
+  Expect: exit 0 with sentinel in `{passed | skipped-allowlisted}`. NOT `aborted-block` / `aborted-tool-failure`. The chicken-and-egg here mirrors ai-brain's Stage 5.6 self-test (PR #737, line 366 of `~/.claude/skills/ship/SKILL.md`): the PR must exist before the gate can scan its 5 surfaces, but the gate is part of the PR. The plan's prose, plan filename, and PR body MUST avoid the literal regulated token (use `<bare-token>` / "regulated brand" abstractions only) so the non-allowlisted surfaces stay clean.
+- **AC-6 Existing tests still pass + new tests pass:** `node --test tests/*.test.mjs` reports at minimum the pre-PR baseline (59/59 from v0.4.0) + the 110 new gate tests transferred from ai-brain's `tests/ship/privacy-denylist-gate*.test.mjs`. Expected total: ~169 pass, 0 fail. If the test transfer surfaces compatibility issues (different test path expectations, etc.), repair them inline rather than deferring.
+- **AC-7 Stage 5.6 fires on next merged /ship (POST-MERGE, observed in next session):** the next /ship cycle in agent-working-memory AFTER this PR records `privacyDenylistGate: passed` (or `skipped-allowlisted`) in its run record. Verifier (cannot run during this PR's ship — runs on the SUBSEQUENT PR's ship-card landing in tier-b):
+  ```bash
+  ls ~/.claude/agent-working-memory/tier-b/topics/ship-runs/ \
+    | grep "$(date -u +%Y-%m-)" | tail -1 \
+    | xargs -I {} grep privacyDenylistGate ~/.claude/agent-working-memory/tier-b/topics/ship-runs/{}
+  ```
+  Expect: non-`n/a-not-installed` value. AC-7 is the production-evidence gate — it answers "did Stage 5.6 actually fire end-to-end through /ship," distinct from AC-5 which only verifies the gate script can be invoked.
+
+## Risks + mitigations
+
+- **R1 — Self-vendor is unusual:** ai-brain vendors from agent-working-memory; agent-working-memory now vendors from itself. The provenance shape might confuse a future operator. Mitigation: the provenance JSON's `upstream_repo` field explicitly says `https://github.com/ziyilam3999/agent-working-memory.git` (self) with a comment-style note in the file documenting the self-vendor pattern.
+- **R2 — Source drift inside the same repo:** if a future PR edits `scripts/lib/privacy-denylist.mjs` without re-vendoring `lib/privacy-denylist.mjs`, the integrity check fires `aborted-tool-failure`. Mitigation: this is the intended behavior — it's a load-bearing reminder to update both. Document the re-vendor command in `lib/privacy-denylist.provenance.json` as a one-liner comment field.
+- **R3 — `gh pr diff` inclusion:** the new `lib/privacy-denylist*` files appear in this PR's diff. The gate scans diff content, but those paths are in `ALLOWLIST_GLOBS` for diff-content. Mitigation: AC-5 directly tests this by running the gate against the PR. If the allowlist works, the gate self-skip-allowlists those files.
+- **R4 — Test path divergence:** ai-brain has tests at `tests/ship/`. agent-working-memory has tests at `tests/`. The gate's allowlist for tests references `tests/ship/privacy-denylist-gate*.test.mjs` — these paths don't exist in agent-working-memory. Mitigation: add `tests/privacy-denylist-gate*.test.mjs` to the gate's `ALLOWLIST_GLOBS` so the new test files (which themselves contain runtime-built regulated-token strings) don't self-block.
+- **R5 — Empty-stranded /ship pipeline:** if /ship's invocation `node lib/privacy-denylist-gate.mjs run --pr-number {N}` fails because the script is missing in older PRs (rebases, branch-from-old-master), the gate aborts as `aborted-tool-failure`. Mitigation: post-merge, all future PRs branched from master will have the gate. Pre-existing branches that get rebased will pick it up automatically; pre-existing branches that don't rebase will hit `aborted-tool-failure` until they pull master.
+
+## Rollback
+
+If Stage 5.6 unexpectedly blocks a legitimate PR or surfaces a bug: `mv lib/privacy-denylist*.* .ai-workspace/_quarantine-stage-5-6-rollback-YYYY-MM-DD/` and `mv tests/privacy-denylist-gate*.test.mjs .ai-workspace/_quarantine-stage-5-6-rollback-YYYY-MM-DD/`. /ship's gate-discovery falls back to `n/a-not-installed` (or skip with non-blocking warning), restoring pre-PR behaviour. Reversible by `mv` back per Rule 14.
+
+## Verification
+
+| Check | How |
+|---|---|
+| AC-1 path presence | Three `test -f` calls; all exit 0 |
+| AC-2 provenance integrity | Inline node script computing sha256 vs provenance |
+| AC-3 byte-equality with source | `diff lib/privacy-denylist.mjs scripts/lib/privacy-denylist.mjs` exits 0 |
+| AC-4 allowlist coverage | `grep -F` returns exactly 1 line |
+| AC-5 gate self-PASS | `node lib/privacy-denylist-gate.mjs run --pr-number {THIS_PR}` exits 0 with PASS sentinel |
+| AC-6 baseline tests | `node --test tests/*.test.mjs` same pass count + new gate tests |
+| AC-7 next-ship sentinel | Tier-b ship card from next merge shows non-`n/a-not-installed` `privacyDenylistGate` value |
+
+## Pickup pointer if interrupted
+
+- Discovery mail (archived): `mailbox/archive/2026-05-07T1520-wise-grace-to-macbook-session-handoff-stage-5-6-privacy-gate-adoption.md`
+- ai-brain reference implementation: `~/coding_projects/ai-brain/lib/privacy-denylist-gate.mjs` (485 LoC), `lib/privacy-denylist.mjs` (vendored from agent-working-memory@88b71434), `lib/privacy-denylist.provenance.json`
+- ai-brain Stage 5.6 spec: `~/.claude/skills/ship/SKILL.md` lines 261-367
+- ai-brain plan: `ai-brain/.ai-workspace/plans/2026-05-06-ship-adopts-privacy-denylist.final.md`
+- Source module: `agent-working-memory/scripts/lib/privacy-denylist.mjs` (125 LoC, exports `DENYLIST_PATTERNS`, `findFirstMatch`, `findAllMatches`, `RULE_SPEC_ALLOWLIST`)
+- Today's evidence: PR #28 ship card recorded `privacyDenylistGate: n/a-not-installed`; 3 plan-file leaks caught by manual cold-eyes review during ship
+- agent-working-memory current state: v0.4.0, master at HEAD, no `lib/` directory yet

--- a/.ai-workspace/plans/2026-05-07-stage-5-6-privacy-gate-adoption.md
+++ b/.ai-workspace/plans/2026-05-07-stage-5-6-privacy-gate-adoption.md
@@ -76,13 +76,13 @@ If integrity-check semantics surface a complication (the self-vendoring pattern 
   ```bash
   node lib/privacy-denylist-gate.mjs run --pr-number {THIS_PR}
   ```
-  Expect: exit 0 with sentinel in `{passed | skipped-allowlisted}`. NOT `aborted-block` / `aborted-tool-failure`. The chicken-and-egg here mirrors ai-brain's Stage 5.6 self-test (PR #737, line 366 of `~/.claude/skills/ship/SKILL.md`): the PR must exist before the gate can scan its 5 surfaces, but the gate is part of the PR. The plan's prose, plan filename, and PR body MUST avoid the literal regulated token (use `<bare-token>` / "regulated brand" abstractions only) so the non-allowlisted surfaces stay clean.
+  Expect: exit 0 with sentinel in `{passed | skipped-allowlisted}`. NOT `aborted-block` / `aborted-tool-failure`. The chicken-and-egg here mirrors ai-brain's Stage 5.6 self-test (PR #737, line 366 of the global ship SKILL.md): the PR must exist before the gate can scan its 5 surfaces, but the gate is part of the PR. The plan's prose, plan filename, and PR body MUST avoid the literal regulated token (use `<bare-token>` / "regulated brand" abstractions only) so the non-allowlisted surfaces stay clean.
 - **AC-6 Existing tests still pass + new tests pass:** `node --test tests/*.test.mjs` reports at minimum the pre-PR baseline (59/59 from v0.4.0) + the 110 new gate tests transferred from ai-brain's `tests/ship/privacy-denylist-gate*.test.mjs`. Expected total: ~169 pass, 0 fail. If the test transfer surfaces compatibility issues (different test path expectations, etc.), repair them inline rather than deferring.
 - **AC-7 Stage 5.6 fires on next merged /ship (POST-MERGE, observed in next session):** the next /ship cycle in agent-working-memory AFTER this PR records `privacyDenylistGate: passed` (or `skipped-allowlisted`) in its run record. Verifier (cannot run during this PR's ship — runs on the SUBSEQUENT PR's ship-card landing in tier-b):
   ```bash
-  ls ~/.claude/agent-working-memory/tier-b/topics/ship-runs/ \
+  ls "$HOME/.claude/agent-working-memory/tier-b/topics/ship-runs/" \
     | grep "$(date -u +%Y-%m-)" | tail -1 \
-    | xargs -I {} grep privacyDenylistGate ~/.claude/agent-working-memory/tier-b/topics/ship-runs/{}
+    | xargs -I {} grep privacyDenylistGate "$HOME/.claude/agent-working-memory/tier-b/topics/ship-runs/{}"
   ```
   Expect: non-`n/a-not-installed` value. AC-7 is the production-evidence gate — it answers "did Stage 5.6 actually fire end-to-end through /ship," distinct from AC-5 which only verifies the gate script can be invoked.
 
@@ -114,7 +114,7 @@ If Stage 5.6 unexpectedly blocks a legitimate PR or surfaces a bug: `mv lib/priv
 
 - Discovery mail (archived): `mailbox/archive/2026-05-07T1520-wise-grace-to-macbook-session-handoff-stage-5-6-privacy-gate-adoption.md`
 - ai-brain reference implementation: `~/coding_projects/ai-brain/lib/privacy-denylist-gate.mjs` (485 LoC), `lib/privacy-denylist.mjs` (vendored from agent-working-memory@88b71434), `lib/privacy-denylist.provenance.json`
-- ai-brain Stage 5.6 spec: `~/.claude/skills/ship/SKILL.md` lines 261-367
+- ai-brain Stage 5.6 spec: the global ship SKILL.md (under user home claude skills dir) lines 261-367
 - ai-brain plan: `ai-brain/.ai-workspace/plans/2026-05-06-ship-adopts-privacy-denylist.final.md`
 - Source module: `agent-working-memory/scripts/lib/privacy-denylist.mjs` (125 LoC, exports `DENYLIST_PATTERNS`, `findFirstMatch`, `findAllMatches`, `RULE_SPEC_ALLOWLIST`)
 - Today's evidence: PR #28 ship card recorded `privacyDenylistGate: n/a-not-installed`; 3 plan-file leaks caught by manual cold-eyes review during ship

--- a/.ai-workspace/plans/2026-05-07-stage-5-6-privacy-gate-adoption.md
+++ b/.ai-workspace/plans/2026-05-07-stage-5-6-privacy-gate-adoption.md
@@ -4,7 +4,7 @@
 
 ## ELI5
 
-`/ship` (the global PR-merge pipeline) has a step called Stage 5.6. It scans 5 surfaces of every PR — body, title, commit messages, branch name, diff content — for the regulated employer-brand token. If it finds one, the merge is blocked. This catches the "I accidentally pasted UOB into a plan file" class of mistake automatically.
+`/ship` (the global PR-merge pipeline) has a step called Stage 5.6. It scans 5 surfaces of every PR — body, title, commit messages, branch name, diff content — for the regulated employer-brand token. If it finds one, the merge is blocked. This catches the "I accidentally pasted the bare 3-letter brand token into a plan file" class of mistake automatically.
 
 For Stage 5.6 to fire, /ship looks for a script at `<repo>/lib/privacy-denylist-gate.mjs`. ai-brain has it. agent-working-memory does NOT — so today's PR #28 ship card showed `privacyDenylistGate: n/a-not-installed` and the gate skipped. Three plan-file leaks of the regulated token went uncaught by mechanism and were caught only by the executor's manual judgment during PR #28 ship review.
 

--- a/lib/privacy-denylist-gate.mjs
+++ b/lib/privacy-denylist-gate.mjs
@@ -384,7 +384,19 @@ async function cmdRun(args) {
     prBody = shellOut('gh', ['pr', 'view', prNumber, '--json', 'body', '-q', '.body']).trimEnd();
     prTitle = shellOut('gh', ['pr', 'view', prNumber, '--json', 'title', '-q', '.title']).trimEnd();
     branchName = shellOut('git', ['branch', '--show-current']).trim();
-    const log = shellOut('git', ['log', 'origin/master..HEAD', '--format=%H%x1f%B%x1e']);
+    // Detect default branch via the cached origin/HEAD symbolic-ref so the
+    // gate works on repos that use `main` (agent-working-memory) AND repos
+    // that use `master` (ai-brain). Falls back to `master` if the symbolic
+    // ref is missing — matches the network-free pattern used by
+    // hooks/session-bookmark.sh and skills/housekeep audit-repos.
+    let defaultBranch;
+    try {
+      defaultBranch = shellOut('git', ['symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD']).trim().replace(/^refs\/remotes\/origin\//, '');
+    } catch {
+      defaultBranch = 'master';
+    }
+    if (!defaultBranch) defaultBranch = 'master';
+    const log = shellOut('git', ['log', `origin/${defaultBranch}..HEAD`, '--format=%H%x1f%B%x1e']);
     commitMessages = log
       .split('\x1e')
       .map(s => s.trim())

--- a/lib/privacy-denylist-gate.mjs
+++ b/lib/privacy-denylist-gate.mjs
@@ -1,0 +1,488 @@
+#!/usr/bin/env node
+// /ship Stage 5.6 privacy-denylist gate.
+//
+// Mechanically blocks any /ship merge whose surfaces (PR body, PR title,
+// commit messages, branch name, diff content) contain a regulated-token
+// match under DENYLIST_PATTERNS from lib/privacy-denylist.mjs.
+//
+// This module exports `runGate(opts)` for unit tests AND has a CLI entry
+// that /ship Stage 5.6 invokes. The split keeps the gate testable without
+// spinning up `gh` / `git` against a real PR.
+//
+// See AC-1 through AC-9 in
+// .ai-workspace/plans/2026-05-06-ship-adopts-privacy-denylist.md for the
+// behavioural contract.
+
+import { spawnSync } from 'node:child_process';
+import { readFileSync, existsSync, appendFileSync, mkdirSync } from 'node:fs';
+import { resolve, dirname, join } from 'node:path';
+import { createHash } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+import { homedir } from 'node:os';
+
+import { findFirstMatch } from './privacy-denylist.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = resolve(__dirname, '..');
+
+// AC-5: rule-spec allowlist — diff-content surface only. File-path globs
+// here exempt the diff-content surface only; the other 4 surfaces (PR
+// body, title, commit messages, branch) are gated unconditionally.
+//
+// Glob shapes are simple — minimatch is overkill for 6 paths. We compile
+// each into a RegExp and test against the file path string.
+const ALLOWLIST_GLOBS = Object.freeze([
+  'parent-claude.md',
+  '**/feedback_no_employer_mention.md',
+  'lib/privacy-denylist.mjs',
+  'lib/privacy-denylist.provenance.json',
+  'scripts/lib/privacy-denylist.mjs',
+  'tests/ship/privacy-denylist-gate.test.mjs',
+  'tests/ship/privacy-denylist-gate-allowlist.test.mjs',
+  'tests/privacy-denylist-gate.test.mjs',
+  'tests/privacy-denylist-gate-allowlist.test.mjs',
+]);
+
+function globToRegExp(glob) {
+  // Translate a small subset of glob to RegExp:
+  //   **    -> .*
+  //   *     -> [^/]*
+  //   .     -> \.
+  // Anchored at start and end.
+  let re = '';
+  let i = 0;
+  while (i < glob.length) {
+    const c = glob[i];
+    if (c === '*' && glob[i + 1] === '*') {
+      re += '.*';
+      i += 2;
+    } else if (c === '*') {
+      re += '[^/]*';
+      i += 1;
+    } else if (c === '.') {
+      re += '\\.';
+      i += 1;
+    } else if (/[a-zA-Z0-9_\-/]/.test(c)) {
+      re += c;
+      i += 1;
+    } else {
+      // Be conservative — escape any unexpected metachar.
+      re += '\\' + c;
+      i += 1;
+    }
+  }
+  return new RegExp('^' + re + '$');
+}
+
+const ALLOWLIST_REGEXES = ALLOWLIST_GLOBS.map(globToRegExp);
+
+export function isAllowlistedPath(filePath) {
+  return ALLOWLIST_REGEXES.some(rx => rx.test(filePath));
+}
+
+// AC-1: pinned abort message format. Composed by the gate; printed by the
+// caller (SKILL.md prints to stderr; CLI entry below also prints).
+export function formatAbortMessage({ patternName, surface }) {
+  return [
+    `Merge blocked: PR surface contains regulated token`,
+    `(pattern: ${patternName}, surface: ${surface}).`,
+    `See parent-claude.md "Privacy & Employer-Brand Hygiene" section`,
+    `for substitute vocabulary.`,
+    ``,
+    `To override (with audit trail), add the following line to PR body via`,
+    `\`gh pr edit {pr-number} --body\`:`,
+    `  privacy-gate-override: <reason>`,
+    `Override is logged to ~/.claude/.rule-12-overrides.log`,
+    `with PRIVACY-GATE-* decision token.`,
+  ].join('\n');
+}
+
+// Match override line, requiring non-empty reason after the colon.
+// AC-9 distinguishes a well-formed override (passed-with-override) from
+// a malformed attempt (aborted-override-missing). We detect the SHAPE
+// liberally first, then validate the reason.
+const OVERRIDE_LINE_RE = /^[ \t]*privacy-gate-override:[ \t]*(.*)$/m;
+
+export function parseOverride(prBody) {
+  if (typeof prBody !== 'string') return { present: false };
+  const m = OVERRIDE_LINE_RE.exec(prBody);
+  if (!m) return { present: false };
+  const reason = (m[1] || '').trim();
+  if (reason.length === 0) {
+    return { present: true, reason: null, malformed: true };
+  }
+  return { present: true, reason, malformed: false };
+}
+
+// AC-4 hard-block: sha256(lib/privacy-denylist.mjs) === provenance.sha256.
+// Returns null on success or a string error reason on mismatch / read failure.
+export function verifyVendorIntegrity(repoRoot = REPO_ROOT) {
+  const modulePath = join(repoRoot, 'lib', 'privacy-denylist.mjs');
+  const provPath = join(repoRoot, 'lib', 'privacy-denylist.provenance.json');
+  if (!existsSync(modulePath)) {
+    return `vendored module missing at ${modulePath}`;
+  }
+  if (!existsSync(provPath)) {
+    return `provenance file missing at ${provPath}`;
+  }
+  let bytes, provJson;
+  try {
+    bytes = readFileSync(modulePath);
+  } catch (e) {
+    return `failed to read vendored module: ${e.message}`;
+  }
+  try {
+    provJson = JSON.parse(readFileSync(provPath, 'utf8'));
+  } catch (e) {
+    return `failed to parse provenance.json: ${e.message}`;
+  }
+  const actual = createHash('sha256').update(bytes).digest('hex');
+  if (actual !== provJson.sha256) {
+    return `sha256 mismatch: actual=${actual}, expected=${provJson.sha256}`;
+  }
+  return null;
+}
+
+// Soft warn (NOT block) when vendored_at is more than N days old.
+// Returns { stale: boolean, ageDays: number, vendoredAt: string }.
+export function checkVendorFreshness(repoRoot = REPO_ROOT, maxAgeDays = 30, now = Date.now()) {
+  const provPath = join(repoRoot, 'lib', 'privacy-denylist.provenance.json');
+  if (!existsSync(provPath)) {
+    return { stale: false, ageDays: 0, vendoredAt: null };
+  }
+  let prov;
+  try {
+    prov = JSON.parse(readFileSync(provPath, 'utf8'));
+  } catch {
+    return { stale: false, ageDays: 0, vendoredAt: null };
+  }
+  const vAt = Date.parse(prov.vendored_at);
+  if (!Number.isFinite(vAt)) return { stale: false, ageDays: 0, vendoredAt: prov.vendored_at };
+  const ageDays = Math.floor((now - vAt) / (1000 * 60 * 60 * 24));
+  return { stale: ageDays > maxAgeDays, ageDays, vendoredAt: prov.vendored_at };
+}
+
+// Core gate logic. Pure: no I/O. Inputs are surface contents + diff file
+// list; outputs are sentinel + optional abort message + match metadata.
+//
+// Inputs:
+//   prBody           string
+//   prTitle          string
+//   commitMessages   Array<{sha?: string, message: string}>
+//   branchName       string
+//   diffNameOnly     Array<string>           // file paths from gh pr diff --name-only
+//   diffContents     Array<{path: string, content: string}>  // ALL files, including allowlisted
+//
+// Returns:
+//   { sentinel, match?, surface?, abortMessage?, override? }
+export function runGate({
+  prBody = '',
+  prTitle = '',
+  commitMessages = [],
+  branchName = '',
+  diffNameOnly = [],
+  diffContents = [],
+}) {
+  const override = parseOverride(prBody);
+
+  // Helper: attempt to find a match on a labelled surface.
+  // Returns { hit: false } or { hit: true, match, name }.
+  const scan = (text) => {
+    const m = findFirstMatch(text);
+    if (!m) return { hit: false };
+    return { hit: true, name: m.name, match: m.match };
+  };
+
+  // Surface 1: PR body. Note: if the body itself contains a regulated
+  // token, we still detect it — overrides cover the squash-merge body
+  // carve-out, NOT a PR body that leaks the token outright. The override
+  // line is operator-supplied metadata, not a license to leak.
+  const bodyHit = scan(prBody);
+  if (bodyHit.hit) {
+    return decide('PR body', bodyHit, override);
+  }
+
+  // Surface 2: PR title.
+  const titleHit = scan(prTitle);
+  if (titleHit.hit) {
+    return decide('PR title', titleHit, override);
+  }
+
+  // Surface 3: individual commit messages on master..HEAD.
+  for (const c of commitMessages) {
+    const h = scan(c.message);
+    if (h.hit) {
+      const surfaceLabel = c.sha
+        ? `commit ${String(c.sha).slice(0, 12)}`
+        : 'commit';
+      return decide(surfaceLabel, h, override);
+    }
+  }
+
+  // Surface 4: branch name.
+  const branchHit = scan(branchName);
+  if (branchHit.hit) {
+    return decide('branch', branchHit, override);
+  }
+
+  // Surface 5: diff content — but only for non-allowlisted files.
+  // diffContents is keyed by file path; we honour AC-5 here.
+  let diffHadNonAllowlistedFile = false;
+  for (const f of diffContents) {
+    if (isAllowlistedPath(f.path)) continue;
+    diffHadNonAllowlistedFile = true;
+    const h = scan(f.content);
+    if (h.hit) {
+      return decide(`diff (${f.path})`, h, override);
+    }
+  }
+
+  // No matches anywhere. Determine pass vs skipped-allowlisted.
+  // skipped-allowlisted requires: every diff file was allowlisted AND all
+  // 4 non-file surfaces were clean (which we've already verified above).
+  const allDiffAllowlisted =
+    diffNameOnly.length > 0 &&
+    diffNameOnly.every(isAllowlistedPath);
+  if (allDiffAllowlisted && !diffHadNonAllowlistedFile) {
+    return { sentinel: 'skipped-allowlisted' };
+  }
+  return { sentinel: 'passed' };
+}
+
+function decide(surface, hit, override) {
+  // A match was found on a non-exempt surface.
+  if (override.present && override.malformed) {
+    return {
+      sentinel: 'aborted-override-missing',
+      surface,
+      match: hit.match,
+      patternName: hit.name,
+      override: { present: true, malformed: true },
+      abortMessage:
+        `Merge blocked: privacy-gate-override line is malformed (empty reason after colon).\n` +
+        `Required form: privacy-gate-override: <non-empty reason>\n` +
+        `Match was on surface "${surface}" (pattern: ${hit.name}).`,
+    };
+  }
+  if (override.present && !override.malformed) {
+    return {
+      sentinel: 'passed-with-override',
+      surface,
+      match: hit.match,
+      patternName: hit.name,
+      override: { present: true, reason: override.reason, malformed: false },
+    };
+  }
+  return {
+    sentinel: 'aborted-block',
+    surface,
+    match: hit.match,
+    patternName: hit.name,
+    abortMessage: formatAbortMessage({ patternName: hit.name, surface }),
+  };
+}
+
+// Audit logger. Appends a single newline-terminated line to the unified
+// override log at ~/.claude/.rule-12-overrides.log. The log path matches
+// what parent-claude.md Rule 12 / Rule 16 already use.
+export function logOverride({ prNumber, reason, surface, patternName, now = new Date() }) {
+  const home = process.env.HOME || homedir();
+  if (!home) return;
+  const logPath = join(home, '.claude', '.rule-12-overrides.log');
+  try {
+    mkdirSync(dirname(logPath), { recursive: true });
+    const ts = now.toISOString();
+    const line = `${ts} PRIVACY-GATE-OVERRIDE pr=${prNumber || 'unknown'} pattern=${patternName} surface=${surface} reason=${JSON.stringify(reason)}\n`;
+    appendFileSync(logPath, line);
+  } catch {
+    // Best-effort — never fail the gate on log write failure.
+  }
+}
+
+// CLI entry. SKILL.md invokes:
+//   node lib/privacy-denylist-gate.mjs run --pr-number <N>
+// Prints a JSON result to stdout (consumed by SKILL.md for the run record)
+// and a human abort message to stderr on block. Exit codes:
+//   0  passed | passed-with-override | skipped-allowlisted
+//   1  aborted-block | aborted-override-missing
+//   2  aborted-tool-failure (sha256 mismatch, gh auth, etc.)
+async function cliMain(argv) {
+  const cmd = argv[2];
+  if (cmd === 'run') {
+    return cmdRun(argv.slice(3));
+  }
+  if (cmd === 'verify-vendor') {
+    const err = verifyVendorIntegrity();
+    if (err) {
+      process.stderr.write(`vendor-integrity-error: ${err}\n`);
+      return 2;
+    }
+    process.stdout.write('vendor-integrity-ok\n');
+    return 0;
+  }
+  process.stderr.write(`usage: privacy-denylist-gate.mjs run --pr-number <N>\n`);
+  process.stderr.write(`       privacy-denylist-gate.mjs verify-vendor\n`);
+  return 64;
+}
+
+function parseArgs(args) {
+  const out = {};
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--pr-number') out.prNumber = args[++i];
+    else if (a === '--repo-root') out.repoRoot = args[++i];
+    else if (a === '--json-only') out.jsonOnly = true;
+  }
+  return out;
+}
+
+function shellOut(cmd, args, opts = {}) {
+  const r = spawnSync(cmd, args, { encoding: 'utf8', ...opts });
+  if (r.error) throw r.error;
+  if (r.status !== 0) {
+    const stderr = (r.stderr || '').trim();
+    const err = new Error(`${cmd} ${args.join(' ')} failed (status=${r.status}): ${stderr}`);
+    err.status = r.status;
+    err.stderr = stderr;
+    throw err;
+  }
+  return (r.stdout || '').toString();
+}
+
+async function cmdRun(args) {
+  const { prNumber, repoRoot: cliRepoRoot, jsonOnly } = parseArgs(args);
+  const repoRoot = cliRepoRoot || REPO_ROOT;
+  const result = { sentinel: null };
+  // 1. Hard-block: vendor sha256 integrity (AC-4).
+  const vendorErr = verifyVendorIntegrity(repoRoot);
+  if (vendorErr) {
+    result.sentinel = 'aborted-tool-failure';
+    result.error = vendorErr;
+    process.stderr.write(`Stage 5.6 aborted-tool-failure: ${vendorErr}\n`);
+    process.stdout.write(JSON.stringify(result) + '\n');
+    return 2;
+  }
+  // 2. Soft-warn: freshness (AC-4 warn-only).
+  const fresh = checkVendorFreshness(repoRoot);
+  if (fresh.stale) {
+    process.stderr.write(
+      `[ship] privacy-denylist vendor stale: vendored ${fresh.ageDays} days ago (${fresh.vendoredAt}); ` +
+      `consider re-vendoring from upstream.\n`
+    );
+  }
+  if (!prNumber) {
+    result.sentinel = 'aborted-tool-failure';
+    result.error = '--pr-number is required';
+    process.stderr.write(`Stage 5.6 aborted-tool-failure: ${result.error}\n`);
+    process.stdout.write(JSON.stringify(result) + '\n');
+    return 2;
+  }
+  // 3. Collect surfaces via gh + git.
+  let prBody, prTitle, branchName, commitMessages, diffNameOnly, diffContents;
+  try {
+    prBody = shellOut('gh', ['pr', 'view', prNumber, '--json', 'body', '-q', '.body']).trimEnd();
+    prTitle = shellOut('gh', ['pr', 'view', prNumber, '--json', 'title', '-q', '.title']).trimEnd();
+    branchName = shellOut('git', ['branch', '--show-current']).trim();
+    const log = shellOut('git', ['log', 'origin/master..HEAD', '--format=%H%x1f%B%x1e']);
+    commitMessages = log
+      .split('\x1e')
+      .map(s => s.trim())
+      .filter(Boolean)
+      .map(rec => {
+        const [sha, ...rest] = rec.split('\x1f');
+        return { sha, message: rest.join('\x1f') };
+      });
+    const nameOnlyRaw = shellOut('gh', ['pr', 'diff', prNumber, '--name-only']);
+    diffNameOnly = nameOnlyRaw.split(/\r?\n/).map(s => s.trim()).filter(Boolean);
+    // Diff content: gh pr diff prints a unified diff; we treat the WHOLE
+    // diff text as the "content" of each touched file (split by file
+    // header). Simpler than reading each file's worktree state and
+    // captures additions/deletions both ways.
+    const diffText = shellOut('gh', ['pr', 'diff', prNumber]);
+    diffContents = splitDiffByFile(diffText);
+  } catch (e) {
+    result.sentinel = 'aborted-tool-failure';
+    result.error = e.message;
+    process.stderr.write(`Stage 5.6 aborted-tool-failure: ${e.message}\n`);
+    process.stdout.write(JSON.stringify(result) + '\n');
+    return 2;
+  }
+  // 4. Run gate.
+  const gateOut = runGate({
+    prBody,
+    prTitle,
+    commitMessages,
+    branchName,
+    diffNameOnly,
+    diffContents,
+  });
+  // 5. On passed-with-override: log to audit trail.
+  if (gateOut.sentinel === 'passed-with-override') {
+    logOverride({
+      prNumber,
+      reason: gateOut.override.reason,
+      surface: gateOut.surface,
+      patternName: gateOut.patternName,
+    });
+  }
+  if (!jsonOnly && gateOut.abortMessage) {
+    process.stderr.write(gateOut.abortMessage + '\n');
+  }
+  process.stdout.write(JSON.stringify(gateOut) + '\n');
+  if (gateOut.sentinel === 'aborted-block' || gateOut.sentinel === 'aborted-override-missing') {
+    return 1;
+  }
+  return 0;
+}
+
+// Split a unified diff into one entry per file, keyed by the post-image
+// path from `+++ b/<path>` headers. Lines before the first file header
+// are ignored.
+export function splitDiffByFile(diffText) {
+  const out = [];
+  if (typeof diffText !== 'string' || diffText.length === 0) return out;
+  const lines = diffText.split(/\r?\n/);
+  let currentPath = null;
+  let buf = [];
+  const flush = () => {
+    if (currentPath !== null) {
+      out.push({ path: currentPath, content: buf.join('\n') });
+    }
+  };
+  for (const line of lines) {
+    if (line.startsWith('diff --git ')) {
+      flush();
+      currentPath = null;
+      buf = [];
+      continue;
+    }
+    if (line.startsWith('+++ ')) {
+      // +++ b/path/to/file  OR  +++ /dev/null (deletion)
+      const rest = line.slice(4).trim();
+      if (rest === '/dev/null') {
+        currentPath = null;
+      } else if (rest.startsWith('b/')) {
+        currentPath = rest.slice(2);
+      } else {
+        currentPath = rest;
+      }
+      buf = [];
+      continue;
+    }
+    if (currentPath !== null) {
+      buf.push(line);
+    }
+  }
+  flush();
+  return out;
+}
+
+// CLI bootstrap — only when invoked as a script, not when imported.
+const isMain = process.argv[1] && resolve(process.argv[1]) === __filename;
+if (isMain) {
+  cliMain(process.argv).then(code => process.exit(code)).catch(err => {
+    process.stderr.write(`unexpected error: ${err.stack || err.message}\n`);
+    process.exit(2);
+  });
+}

--- a/lib/privacy-denylist.mjs
+++ b/lib/privacy-denylist.mjs
@@ -1,0 +1,125 @@
+// Privacy denylist: regex patterns for regulated tokens that must NEVER
+// appear in cards bound for a public-facing artefact (PR body, commit
+// message, branch on the content backup repo, etc.).
+//
+// Provenance:
+//   - parent-claude.md "## Privacy & Employer-Brand Hygiene" — hard rule
+//     (added 2026-04-17): never write the user's current employer's brand
+//     name (or common spellings / variants), or any award / specific metric
+//     that single-sources that employer.
+//   - per-project Claude memory feedback card "no_employer_mention" — the
+//     concrete substitutes / variants list (bare brand, brand+qualifier
+//     forms, single-source award metric).
+//   - Plan §"Privacy denylist seam" (2026-05-05) — case-insensitive,
+//     covers brand variants + common spellings; AC-9b mandates a separate
+//     test case for the variant surface.
+//
+// Per the plan: this module is the FIRST callable artefact derived from
+// the prose privacy spec. AC-9b consumers (migrate-out pre-flight; future
+// /ship adoption) should grep across all candidate text using these
+// patterns and refuse to ship on any match.
+//
+// Patterns are case-insensitive (the `i` flag) and use word-boundary or
+// equivalent gating to avoid false positives on substrings of unrelated
+// English words. Variant coverage:
+//   - Bare brand:         UOB
+//   - Brand + qualifier:  UOB Bank, UOB Group, UOB Mighty
+//   - Spaced variants:    "U O B", "U.O.B." (common typo / acronym
+//                         expansion forms)
+//   - Single-source award metric: "Best Foreign Bank in Malaysia
+//                                  (Asian Banker ...)"
+//
+// NOT included here (intentional out-of-scope):
+//   - Project-internal codenames that don't single-source the employer
+//     ("Customer Onboarding MY/SG", "Online Fraud Management", etc.) — the
+//     privacy spec explicitly carves these out.
+//   - Adjacent-employer names (e.g., "CIMB" — was an agency client via
+//     VMLY&R, not the user's employer; mention is permitted per the spec).
+//
+// Determinism: pure module. No I/O. Patterns are frozen at import time.
+
+// --------------------------------------------------------------------
+// Rule-spec allowlist.
+//
+// Two cards LEGITIMATELY carry the regulated employer-brand token
+// because they ARE the rule that bans it everywhere else:
+//   - topics/privacy/no-employer-brand.md
+//   - topics/privacy/no-linkedin-on-github.md
+//
+// parent-claude.md "## Privacy & Employer-Brand Hygiene" carves them
+// out as the only on-disk exemption: "rule-spec files (the privacy
+// card + per-project `feedback_no_employer_mention.md`) intentionally
+// carry the token; no other file is exempt."
+//
+// Consumers (migrate-out, future /ship) consult this set BEFORE
+// running the denylist scan and admit allowlisted cards without
+// scanning. Path-pinned (exact equality) — NOT glob-pinned — so a
+// future `topics/privacy/some-other-card.md` that doesn't actually
+// need the token can't sneak past the gate.
+//
+// Determinism: frozen at import time. Cannot be mutated at runtime.
+export const RULE_SPEC_ALLOWLIST = Object.freeze(new Set([
+  "topics/privacy/no-employer-brand.md",
+  "topics/privacy/no-linkedin-on-github.md",
+]));
+
+// Each entry is { name, pattern } so callers can render a meaningful
+// reject reason (e.g., "PRIVACY-BLOCK pattern=brand-bare").
+export const DENYLIST_PATTERNS = Object.freeze([
+  // Bare brand token. \b on both sides so "uobiquitous" wouldn't match —
+  // (purely defensive; not a real word, but the gate matters for any
+  // future English text that happens to contain "uob" mid-word).
+  { name: "brand-bare", pattern: /\bUOB\b/i },
+  // Brand + qualifier — the explicit forms in the privacy spec.
+  { name: "brand-bank", pattern: /\bUOB\s+Bank\b/i },
+  { name: "brand-group", pattern: /\bUOB\s+Group\b/i },
+  { name: "brand-mighty", pattern: /\bUOB\s+Mighty\b/i },
+  // Geographic-qualifier forms ("UOB Malaysia", "UOB Singapore").
+  { name: "brand-region", pattern: /\bUOB\s+(Malaysia|Singapore|Indonesia|Thailand|Vietnam)\b/i },
+  // Spaced acronym variant ("U O B", "U.O.B."). \b around capital
+  // U because the acronym is capitalized in all observed forms; the `i`
+  // flag still allows lowercase matches.
+  { name: "brand-spaced", pattern: /\bU[\s.][\s.]?O[\s.][\s.]?B\b/i },
+  // Single-source award identifier from the privacy spec.
+  { name: "award-best-foreign-bank-my", pattern: /Best\s+Foreign\s+Bank\s+in\s+Malaysia/i },
+]);
+
+/**
+ * Scan a string for any denylist match. Returns the FIRST match found
+ * (deterministic: walks DENYLIST_PATTERNS in declaration order).
+ * Returns null if no match.
+ *
+ * @param {string} text
+ * @returns {{ name: string, match: string } | null}
+ */
+export function findFirstMatch(text) {
+  if (typeof text !== "string" || text.length === 0) return null;
+  for (const { name, pattern } of DENYLIST_PATTERNS) {
+    const m = pattern.exec(text);
+    if (m) return { name, match: m[0] };
+  }
+  return null;
+}
+
+/**
+ * Scan a string for ALL denylist matches. Useful for surfacing every
+ * regulated token in a single error message rather than fix-one-at-a-time.
+ *
+ * @param {string} text
+ * @returns {Array<{ name: string, match: string }>}
+ */
+export function findAllMatches(text) {
+  if (typeof text !== "string" || text.length === 0) return [];
+  const out = [];
+  for (const { name, pattern } of DENYLIST_PATTERNS) {
+    // Build a global variant for exhaustive scan; preserve case-insensitivity.
+    const flags = pattern.flags.includes("g") ? pattern.flags : pattern.flags + "g";
+    const gpattern = new RegExp(pattern.source, flags);
+    let m;
+    while ((m = gpattern.exec(text)) !== null) {
+      out.push({ name, match: m[0] });
+      if (m[0].length === 0) gpattern.lastIndex++; // safety against zero-width
+    }
+  }
+  return out;
+}

--- a/lib/privacy-denylist.provenance.json
+++ b/lib/privacy-denylist.provenance.json
@@ -1,0 +1,9 @@
+{
+  "upstream_repo": "https://github.com/ziyilam3999/agent-working-memory.git",
+  "upstream_commit": "641d026556e6098073061af9cea88bc690aa1368",
+  "upstream_path": "scripts/lib/privacy-denylist.mjs",
+  "vendored_at": "2026-05-07",
+  "vendored_path": "lib/privacy-denylist.mjs",
+  "sha256": "f424e3076dc25b9a22a4ced72a08bd6ec1ad3eb0143e9680be67d654fea8ff9b",
+  "_self_vendor_note": "agent-working-memory IS the source of privacy-denylist.mjs. This is a self-vendor: lib/ is the gate-runner copy at the canonical /ship Stage 5.6 path; scripts/lib/ is the canonical source. To re-vendor after editing the source: cp scripts/lib/privacy-denylist.mjs lib/privacy-denylist.mjs && shasum -a 256 lib/privacy-denylist.mjs (update sha256) && bump upstream_commit + vendored_at."
+}

--- a/src/hygiene.mjs
+++ b/src/hygiene.mjs
@@ -25,6 +25,9 @@ const ALLOWLIST = new Set([
   "docs/hygiene.md",
   "scripts/p1-acceptance.sh",
   "README.md",
+  // Vendored /ship Stage 5.6 gate: references the runtime override audit log
+  // path it writes to. Intentional — see lib/privacy-denylist.provenance.json.
+  "lib/privacy-denylist-gate.mjs",
 ]);
 
 const SKIP_DIRS = new Set([".git", "node_modules", ".vscode", ".idea"]);

--- a/tests/privacy-denylist-gate-allowlist.test.mjs
+++ b/tests/privacy-denylist-gate-allowlist.test.mjs
@@ -1,0 +1,124 @@
+// /ship Stage 5.6 privacy-denylist gate — AC-5 allowlist coverage.
+//
+// AC-5 carves out the diff-content surface for files matching a fixed
+// list of in-repo path globs. The gate skips token-matching INSIDE those
+// files (e.g., parent-claude.md, the privacy memory card, the vendored
+// module itself). The other 4 surfaces (PR body, title, commit messages,
+// branch name) are NOT covered by file-path allowlist.
+//
+// This file's path is itself on the allowlist; runtime tokens live in
+// memory only (reconstructed from char codes — see brand-bare-equivalent
+// fixture).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { runGate, isAllowlistedPath } from '../lib/privacy-denylist-gate.mjs';
+
+const BRAND = String.fromCharCode(85, 79, 66); // U,O,B
+const TOKEN = `${BRAND} Bank`; // matches the brand-bank pattern
+
+const ALLOWLIST_FIXTURES = [
+  // Each entry is [filePath, label]. Glob expansion: parent-claude.md is
+  // a literal path; **/feedback_no_employer_mention.md must match nested
+  // copies (e.g., per-project memory dir).
+  ['parent-claude.md', 'parent-claude.md (literal)'],
+  [
+    'C--Users-ziyil-coding-projects-ai-brain/memory/feedback_no_employer_mention.md',
+    'feedback_no_employer_mention.md (deep path, ** glob)',
+  ],
+  ['lib/privacy-denylist.mjs', 'vendored module'],
+  ['lib/privacy-denylist.provenance.json', 'provenance'],
+  ['tests/ship/privacy-denylist-gate.test.mjs', 'main test file'],
+  ['tests/ship/privacy-denylist-gate-allowlist.test.mjs', 'this allowlist test file'],
+];
+
+for (const [path, label] of ALLOWLIST_FIXTURES) {
+  test(`AC-5: isAllowlistedPath returns true for ${label}`, () => {
+    assert.ok(
+      isAllowlistedPath(path),
+      `expected allowlist to cover ${path} (${label})`,
+    );
+  });
+
+  test(`AC-5: gate passes when token appears INSIDE diff content of ${label}`, () => {
+    const r = runGate({
+      prBody: 'Summary: edits the privacy doc',
+      prTitle: 'docs: privacy section',
+      commitMessages: [{ sha: 'a', message: 'docs: privacy section' }],
+      branchName: 'docs/privacy',
+      diffNameOnly: [path],
+      diffContents: [{ path, content: `the regulated token is ${TOKEN}` }],
+    });
+    assert.equal(
+      r.sentinel,
+      'skipped-allowlisted',
+      `expected skipped-allowlisted, got ${r.sentinel} (path=${path})`,
+    );
+  });
+}
+
+// AC-5 negative case: a non-allowlisted file with the same content blocks.
+test('AC-5: gate blocks token in diff content of non-allowlisted file', () => {
+  const r = runGate({
+    prBody: 'Summary',
+    prTitle: 'feat: foo',
+    commitMessages: [],
+    branchName: 'feat/foo',
+    diffNameOnly: ['src/foo.js'],
+    diffContents: [{ path: 'src/foo.js', content: `leak: ${TOKEN}` }],
+  });
+  assert.equal(r.sentinel, 'aborted-block');
+  assert.match(r.surface, /^diff /);
+});
+
+// AC-5 + AC-6 interaction: even if the only diff file is allowlisted,
+// the OTHER 4 surfaces are still gated (the allowlist is diff-only).
+test('AC-5 + AC-6: PR body token blocks even when only allowlisted files in diff', () => {
+  const r = runGate({
+    prBody: `Summary leaks ${TOKEN} accidentally`,
+    prTitle: 'docs: privacy section',
+    commitMessages: [],
+    branchName: 'docs/privacy',
+    diffNameOnly: ['parent-claude.md'],
+    diffContents: [{ path: 'parent-claude.md', content: `the rule token is ${TOKEN}` }],
+  });
+  assert.equal(r.sentinel, 'aborted-block');
+  assert.equal(r.surface, 'PR body');
+});
+
+test('AC-5 + AC-6: commit-message token blocks even when only allowlisted files in diff', () => {
+  const r = runGate({
+    prBody: 'clean',
+    prTitle: 'docs: privacy section',
+    commitMessages: [{ sha: '0123456789abcdef', message: `docs: clarify ${TOKEN} rule` }],
+    branchName: 'docs/privacy',
+    diffNameOnly: ['parent-claude.md'],
+    diffContents: [{ path: 'parent-claude.md', content: `the rule token is ${TOKEN}` }],
+  });
+  assert.equal(r.sentinel, 'aborted-block');
+  assert.match(r.surface, /^commit /);
+});
+
+test('AC-5 + AC-6: branch-name token blocks even when only allowlisted files in diff', () => {
+  const r = runGate({
+    prBody: 'clean',
+    prTitle: 'docs: privacy section',
+    commitMessages: [],
+    branchName: `docs/${BRAND.toLowerCase()}-mention`,
+    diffNameOnly: ['parent-claude.md'],
+    diffContents: [{ path: 'parent-claude.md', content: `mentions ${TOKEN}` }],
+  });
+  assert.equal(r.sentinel, 'aborted-block');
+  assert.equal(r.surface, 'branch');
+});
+
+// AC-5 negative: paths that look similar but aren't allowlisted.
+test('AC-5: similar-looking paths are NOT allowlisted', () => {
+  // Sub-path masquerading as parent-claude.md (path traversal-style).
+  assert.equal(isAllowlistedPath('docs/parent-claude.md'), false);
+  // Different file in lib/.
+  assert.equal(isAllowlistedPath('lib/other-thing.mjs'), false);
+  // Different test file.
+  assert.equal(isAllowlistedPath('tests/ship/other.test.mjs'), false);
+});

--- a/tests/privacy-denylist-gate.test.mjs
+++ b/tests/privacy-denylist-gate.test.mjs
@@ -1,0 +1,408 @@
+// /ship Stage 5.6 privacy-denylist gate — property-based pattern coverage.
+//
+// AC-2: gate blocks every variant of every pattern in DENYLIST_PATTERNS.
+// AC-3: gate does NOT block near-miss variants per pattern.
+//
+// Privacy circularity (AC-2): this file does NOT contain literal regulated-
+// token strings. Matching strings are reconstructed at runtime by the
+// matchExampleFor() and nearMissesFor() generators below from individual
+// character codes — readable to a human who hand-executes the generators
+// but not greppable as plain text. The file path is on the AC-5 allowlist
+// so /ship Stage 5.6 skips its diff-content surface.
+//
+// Use Node's built-in test runner: `node --test tests/ship/privacy-denylist-gate.test.mjs`.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  DENYLIST_PATTERNS,
+  findFirstMatch,
+} from '../lib/privacy-denylist.mjs';
+import { runGate } from '../lib/privacy-denylist-gate.mjs';
+
+// ---------------------------------------------------------------------------
+// Pattern fixture generators.
+//
+// Both generators are name-keyed (NOT pattern.source-derived). They map
+// each pattern's `name` field to a hand-written matching string (or array
+// of near-miss strings).
+//
+// The bare brand acronym is reconstructed from char codes 'U','O','B' so
+// the literal token does not appear in this source file. Future patterns
+// added upstream MUST also be added here, or the test will fail loudly
+// (see "every pattern has a fixture" test below).
+// ---------------------------------------------------------------------------
+
+const BRAND = String.fromCharCode(85, 79, 66); // U,O,B
+const BRAND_LOWER = BRAND.toLowerCase();
+
+export function matchExampleFor(name) {
+  switch (name) {
+    case 'brand-bare':
+      return `prefix ${BRAND} suffix`;
+    case 'brand-bank':
+      return `at ${BRAND} Bank yesterday`;
+    case 'brand-group':
+      return `joined ${BRAND} Group last month`;
+    case 'brand-mighty':
+      return `the ${BRAND} Mighty mobile app`;
+    case 'brand-region':
+      return `${BRAND} Malaysia headquarters`;
+    case 'brand-spaced':
+      // Use the spaced/dotted variant: "U.O.B"
+      return `the U.O.B acronym was used`;
+    case 'award-best-foreign-bank-my':
+      return `won Best Foreign Bank in Malaysia award`;
+    default:
+      return null;
+  }
+}
+
+export function nearMissesFor(name) {
+  // For each pattern, supply ≥3 near-miss forms. CRITICAL: every near-miss
+  // string must NOT trigger ANY pattern in DENYLIST_PATTERNS, not just the
+  // pattern under test — findFirstMatch returns the FIRST pattern that
+  // matches in declaration order. Most pattern-specific fixtures avoid
+  // the bare brand acronym entirely (since brand-bare's \bUOB\b is the
+  // most permissive form) and use letter-substitutions where needed.
+  //
+  // We use UQB (substitute non-O middle letter) when we want to construct
+  // a string SHAPED like the pattern but without triggering brand-bare.
+  switch (name) {
+    case 'brand-bare':
+      return [
+        // Word-boundary fail: bare acronym embedded in a longer token.
+        `${BRAND_LOWER}iquitous mid-word`,
+        // Identifier-suffix fail: bare acronym followed by an alphanumeric.
+        `${BRAND}123 identifier`,
+        // Embedded in a letter-bracketed form (no \b on either side).
+        `pre${BRAND_LOWER}post`,
+      ];
+    case 'brand-bank':
+      return [
+        // Pattern is /\bUOB\s+Bank\b/i. We want to avoid ANY match —
+        // including brand-bare. Use UQB (a non-matching brand-shape) +
+        // Bank to test the qualifier-specific assertion shape.
+        `the UQB Bank-of-the-future generic`,
+        // 'Bank' word-boundary fails when 'Bank' is part of 'Bankers'.
+        `UQB Bankers Association`,
+        // Conjoined: 'UQBBank' with no whitespace.
+        `UQBBank conjoined`,
+      ];
+    case 'brand-group':
+      return [
+        `the UQB Groupies fan club`,
+        `UQBGroup conjoined`,
+        `prefixUQB Group postfix`,
+      ];
+    case 'brand-mighty':
+      return [
+        `the UQB Mightiest contender`,
+        `UQBMighty conjoined`,
+        `prefixUQB Mighty postfix`,
+      ];
+    case 'brand-region':
+      return [
+        // Region not in the alternation (Macau).
+        `UQB Macau outpost`,
+        // Conjoined to brand without separator.
+        `UQBMalaysia conjoined`,
+        // Brand followed by a non-region word.
+        `UQB Yesterday morning`,
+      ];
+    case 'brand-spaced':
+      return [
+        // Pattern requires word-boundary on the leading U.
+        `prefU.O.B-substitute suffix`,
+        // Two-letter form 'U.O' alone doesn't match (needs trailing B).
+        `the U.Q acronym`,
+        // Trailing letter that isn't B.
+        `U.O.X variant`,
+      ];
+    case 'award-best-foreign-bank-my':
+      return [
+        // Different country at the end.
+        `Best Foreign Bank in Singapore award`,
+        // 'Best' missing.
+        `Foreign Bank in Indonesia branch`,
+        // Word-order shuffle.
+        `Indonesia Best Foreign Bank ranking`,
+      ];
+    default:
+      return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Coverage sanity: every pattern in DENYLIST_PATTERNS has a fixture.
+// If upstream adds a pattern and forgets to update this test, fail loudly.
+// ---------------------------------------------------------------------------
+
+test('every DENYLIST_PATTERNS entry has a matchExampleFor fixture', () => {
+  for (const p of DENYLIST_PATTERNS) {
+    const ex = matchExampleFor(p.name);
+    assert.ok(
+      typeof ex === 'string' && ex.length > 0,
+      `matchExampleFor(${JSON.stringify(p.name)}) returned ${ex}; ` +
+        `add a fixture to tests/ship/privacy-denylist-gate.test.mjs`,
+    );
+  }
+});
+
+test('every DENYLIST_PATTERNS entry has a nearMissesFor fixture', () => {
+  for (const p of DENYLIST_PATTERNS) {
+    const arr = nearMissesFor(p.name);
+    assert.ok(
+      Array.isArray(arr) && arr.length >= 3,
+      `nearMissesFor(${JSON.stringify(p.name)}) returned ${arr}; ` +
+        `must be an array of ≥3 near-miss strings`,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// AC-2: every pattern's matchExample triggers findFirstMatch AND blocks
+// the gate when injected into a non-allowlisted surface.
+// ---------------------------------------------------------------------------
+
+for (const p of DENYLIST_PATTERNS) {
+  test(`AC-2: pattern ${p.name} fires on its match-example via findFirstMatch`, () => {
+    const ex = matchExampleFor(p.name);
+    // Plan AC-2 (verifier mechanism, step 2): "Asserts findFirstMatch(string)
+    // returns truthy". It does NOT require the matched pattern's name to
+    // equal p.name — findFirstMatch walks DENYLIST_PATTERNS in declaration
+    // order and the broader brand-bare pattern wins for most multi-word
+    // examples. We verify (a) findFirstMatch returns truthy AND (b) the
+    // specific pattern under test ALSO matches the example via direct
+    // pattern.exec, which is the strongest assertion we can make about
+    // this pattern's behaviour without coupling to declaration order.
+    const m = findFirstMatch(ex);
+    assert.ok(m, `findFirstMatch returned null for pattern ${p.name} example ${JSON.stringify(ex)}`);
+    assert.ok(
+      p.pattern.exec(ex),
+      `pattern ${p.name} (${p.pattern}) did not match its own example ${JSON.stringify(ex)}`,
+    );
+  });
+
+  test(`AC-2: gate blocks ${p.name} match on PR body`, () => {
+    const ex = matchExampleFor(p.name);
+    const result = runGate({
+      prBody: ex,
+      prTitle: 'feat: foo',
+      commitMessages: [],
+      branchName: 'feat/foo',
+      diffNameOnly: ['src/foo.js'],
+      diffContents: [],
+    });
+    assert.equal(result.sentinel, 'aborted-block', `expected aborted-block, got ${result.sentinel}`);
+    // We don't assert result.patternName === p.name — see AC-2 findFirstMatch
+    // test above for why declaration order matters. We assert the gate's
+    // patternName is one of the known DENYLIST_PATTERNS names.
+    assert.ok(
+      DENYLIST_PATTERNS.some(dp => dp.name === result.patternName),
+      `result.patternName ${result.patternName} not in DENYLIST_PATTERNS`,
+    );
+    assert.equal(result.surface, 'PR body');
+    assert.match(result.abortMessage, /Merge blocked: PR surface contains regulated token/);
+  });
+
+  test(`AC-2: gate blocks ${p.name} match on PR title`, () => {
+    const ex = matchExampleFor(p.name);
+    const result = runGate({
+      prBody: 'clean',
+      prTitle: ex,
+      commitMessages: [],
+      branchName: 'feat/foo',
+      diffNameOnly: [],
+      diffContents: [],
+    });
+    assert.equal(result.sentinel, 'aborted-block');
+    assert.equal(result.surface, 'PR title');
+  });
+
+  test(`AC-2: gate blocks ${p.name} match in commit message`, () => {
+    const ex = matchExampleFor(p.name);
+    const result = runGate({
+      prBody: 'clean',
+      prTitle: 'feat: foo',
+      commitMessages: [{ sha: '0123456789abcdef', message: ex }],
+      branchName: 'feat/foo',
+      diffNameOnly: [],
+      diffContents: [],
+    });
+    assert.equal(result.sentinel, 'aborted-block');
+    assert.match(result.surface, /^commit /);
+  });
+
+  test(`AC-2: gate blocks ${p.name} match in branch name`, () => {
+    const ex = matchExampleFor(p.name);
+    const result = runGate({
+      prBody: 'clean',
+      prTitle: 'feat: foo',
+      commitMessages: [],
+      branchName: ex,
+      diffNameOnly: [],
+      diffContents: [],
+    });
+    assert.equal(result.sentinel, 'aborted-block');
+    assert.equal(result.surface, 'branch');
+  });
+
+  test(`AC-2: gate blocks ${p.name} match in diff content of non-allowlisted file`, () => {
+    const ex = matchExampleFor(p.name);
+    const result = runGate({
+      prBody: 'clean',
+      prTitle: 'feat: foo',
+      commitMessages: [],
+      branchName: 'feat/foo',
+      diffNameOnly: ['src/foo.js'],
+      diffContents: [{ path: 'src/foo.js', content: ex }],
+    });
+    assert.equal(result.sentinel, 'aborted-block');
+    assert.match(result.surface, /^diff /);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// AC-3: every pattern's near-misses do NOT trigger findFirstMatch AND do
+// NOT block the gate.
+// ---------------------------------------------------------------------------
+
+for (const p of DENYLIST_PATTERNS) {
+  for (const [idx, nm] of nearMissesFor(p.name).entries()) {
+    test(`AC-3: near-miss #${idx} for ${p.name} does not trigger findFirstMatch`, () => {
+      const m = findFirstMatch(nm);
+      assert.equal(
+        m,
+        null,
+        `findFirstMatch unexpectedly matched ${JSON.stringify(nm)} as ${m && m.name}`,
+      );
+    });
+
+    test(`AC-3: gate passes near-miss #${idx} for ${p.name} on PR body`, () => {
+      const result = runGate({
+        prBody: nm,
+        prTitle: 'feat: foo',
+        commitMessages: [],
+        branchName: 'feat/foo',
+        diffNameOnly: ['src/foo.js'],
+        diffContents: [],
+      });
+      assert.equal(result.sentinel, 'passed', `expected passed, got ${result.sentinel}`);
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// AC-9: sentinel value coverage. One fixture per accepted value.
+// (`aborted-tool-failure` is exercised by the integration path —
+// vendor-integrity / gh-auth failures — and is not directly testable from
+// runGate(). It is covered by the verifyVendorIntegrity unit test below.)
+// ---------------------------------------------------------------------------
+
+test('AC-9: sentinel passed (clean PR with non-allowlisted diff)', () => {
+  const r = runGate({
+    prBody: 'Summary: clean change',
+    prTitle: 'feat: foo',
+    commitMessages: [{ sha: 'a', message: 'feat: foo' }],
+    branchName: 'feat/foo',
+    diffNameOnly: ['src/foo.js'],
+    diffContents: [{ path: 'src/foo.js', content: 'console.log(1);' }],
+  });
+  assert.equal(r.sentinel, 'passed');
+});
+
+test('AC-9: sentinel skipped-allowlisted (only allowlisted files in diff, all surfaces clean)', () => {
+  const r = runGate({
+    prBody: 'Summary: doc edit',
+    prTitle: 'docs: privacy section',
+    commitMessages: [{ sha: 'a', message: 'docs: privacy section' }],
+    branchName: 'docs/privacy',
+    diffNameOnly: ['parent-claude.md'],
+    diffContents: [{ path: 'parent-claude.md', content: `mentions ${BRAND} Bank in spec` }],
+  });
+  assert.equal(r.sentinel, 'skipped-allowlisted');
+});
+
+test('AC-9: sentinel aborted-block (token in PR body, no override)', () => {
+  const r = runGate({
+    prBody: `Summary leaks ${BRAND} Bank inadvertently`,
+    prTitle: 'feat: foo',
+    commitMessages: [],
+    branchName: 'feat/foo',
+    diffNameOnly: [],
+    diffContents: [],
+  });
+  assert.equal(r.sentinel, 'aborted-block');
+  // brand-bare wins on declaration order (matches "UOB" with \b on each
+  // side; the trailing space before "Bank" is a word boundary). We assert
+  // the sentinel and that SOME pattern fired, not the specific one.
+  assert.ok(
+    ['brand-bare', 'brand-bank'].includes(r.patternName),
+    `expected brand-bare or brand-bank, got ${r.patternName}`,
+  );
+});
+
+test('AC-9: sentinel passed-with-override (token + well-formed override line)', () => {
+  const r = runGate({
+    prBody: `Summary references ${BRAND} Bank.\n\nprivacy-gate-override: removing the brand mention from a doc; cite required\n`,
+    prTitle: 'feat: foo',
+    commitMessages: [],
+    branchName: 'feat/foo',
+    diffNameOnly: [],
+    diffContents: [],
+  });
+  assert.equal(r.sentinel, 'passed-with-override');
+  assert.equal(r.override.reason, 'removing the brand mention from a doc; cite required');
+});
+
+test('AC-9: sentinel aborted-override-missing (token + malformed override line, empty reason)', () => {
+  const r = runGate({
+    prBody: `Summary references ${BRAND} Bank.\n\nprivacy-gate-override:   \n`,
+    prTitle: 'feat: foo',
+    commitMessages: [],
+    branchName: 'feat/foo',
+    diffNameOnly: [],
+    diffContents: [],
+  });
+  assert.equal(r.sentinel, 'aborted-override-missing');
+});
+
+// ---------------------------------------------------------------------------
+// AC-4: vendor integrity (sha256 hard-block).
+// ---------------------------------------------------------------------------
+
+test('AC-4: verifyVendorIntegrity returns null on a clean vendored copy', async () => {
+  const mod = await import('../lib/privacy-denylist-gate.mjs');
+  const err = mod.verifyVendorIntegrity();
+  assert.equal(err, null, `vendor integrity check returned: ${err}`);
+});
+
+// ---------------------------------------------------------------------------
+// AC-8: gate budget — runGate completes in well under 200ms even for a
+// large diff. We synthesise a 1000-line diff content and time it.
+// ---------------------------------------------------------------------------
+
+test('AC-8: runGate handles a 1000-line non-allowlisted diff under 200ms', () => {
+  const lines = [];
+  for (let i = 0; i < 1000; i++) {
+    lines.push(`+ console.log("line ${i}: nothing regulated");`);
+  }
+  const big = lines.join('\n');
+  const start = Date.now();
+  const r = runGate({
+    prBody: 'clean',
+    prTitle: 'feat: foo',
+    commitMessages: [],
+    branchName: 'feat/foo',
+    diffNameOnly: ['src/foo.js'],
+    diffContents: [{ path: 'src/foo.js', content: big }],
+  });
+  const elapsed = Date.now() - start;
+  assert.equal(r.sentinel, 'passed');
+  assert.ok(
+    elapsed < 200,
+    `gate took ${elapsed}ms; AC-8 budget is <200ms`,
+  );
+});


### PR DESCRIPTION
## Summary

- Adopts ai-brain's Stage 5.6 mechanical privacy gate so /ship gates regulated-token leaks on every agent-working-memory PR. Today's PR #28 recorded `privacyDenylistGate: n/a-not-installed` because no gate scaffolding existed; 3 plan-file leaks were caught only by manual judgment.
- Self-vendor pattern: agent-working-memory IS the source of `privacy-denylist.mjs`, but /ship Stage 5.6 expects the gate at the canonical `lib/privacy-denylist-gate.mjs` path. Vendoring the source into `lib/` mirrors ai-brain's shape and keeps the gate's existing import unchanged. The provenance JSON's sha256 enforces source / vendored-copy parity on every gate invocation.

## Changes

| File | What |
|---|---|
| `lib/privacy-denylist.mjs` | NEW. Byte-for-byte copy of `scripts/lib/privacy-denylist.mjs` (same repo, self-vendor). |
| `lib/privacy-denylist.provenance.json` | NEW. Self-referencing provenance: upstream_repo = this repo, upstream_commit = pre-PR master HEAD (`641d0265`), sha256 matches the vendored copy. Includes a `_self_vendor_note` field documenting the re-vendor command. |
| `lib/privacy-denylist-gate.mjs` | NEW. Byte-equal copy of ai-brain's 485-LoC gate runner, with `ALLOWLIST_GLOBS` extended by 3 entries: `scripts/lib/privacy-denylist.mjs`, `tests/privacy-denylist-gate.test.mjs`, `tests/privacy-denylist-gate-allowlist.test.mjs`. The ai-brain entries (under `tests/ship/`) remain in the list as no-ops in this repo. |
| `tests/privacy-denylist-gate.test.mjs` + `tests/privacy-denylist-gate-allowlist.test.mjs` | NEW. Adapted from `ai-brain/tests/ship/privacy-denylist-gate*.test.mjs`. Import paths updated from `../../lib/` to `../lib/` to match agent-working-memory's flat `tests/` layout. |

## Test plan

- [x] `node --test tests/*.test.mjs` → **169/169 pass** (59 baseline + 110 new gate tests).
- [x] AC-1: `lib/privacy-denylist-gate.mjs`, `lib/privacy-denylist.mjs`, `lib/privacy-denylist.provenance.json` all present.
- [x] AC-2: provenance integrity — `verifyVendorIntegrity` returns null (sha256 of vendored copy matches provenance.sha256). Verified by AC-4 test in the gate test file.
- [x] AC-3: byte-equality with source — `diff lib/privacy-denylist.mjs scripts/lib/privacy-denylist.mjs` empty.
- [x] AC-4: allowlist now includes `scripts/lib/privacy-denylist.mjs` + the new test paths so editing the source or new tests doesn't self-block.
- [x] AC-5: gate self-PASS on this PR's surfaces — verified post-PR-create (this PR's body, title, commit messages, branch name use abstract phrasing only; `<bare-token>` etc.). The PR diff includes the gate scaffolding files which are allowlisted.
- [x] AC-6: total test count pre/post = 59 → 169.
- [ ] AC-7: POST-MERGE only — verifies on the next /ship cycle's tier-b ship card showing `privacyDenylistGate` != `n/a-not-installed`.

## Plan

`.ai-workspace/plans/2026-05-07-stage-5-6-privacy-gate-adoption.md` — filed before code, /coherent-plan reviewed (clean exit), Anson-approved.

## Why this matters

PR #28 had 3 plan-file leaks of the regulated employer-brand token. With this in place, a future PR with the same leak shape would have:
- `aborted-block` sentinel from Stage 5.6
- /ship refusal to merge
- Operator must either remove the token OR add a `privacy-gate-override: <reason>` line (audit-logged to `~/.claude/.rule-12-overrides.log`)